### PR TITLE
Export enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ version = "1.0"
 [dev-dependencies]
 criterion = "0.3.5"
 num_cpus = "1.13.0"
-simple_logger = "1.13.0"
+simple_logger = "1.16.0"
 
 [dev-dependencies.tokio]
 features = ["rt-multi-thread", "macros"]

--- a/benches/is_enabled.rs
+++ b/benches/is_enabled.rs
@@ -214,6 +214,7 @@ fn random_str() -> String {
 
 fn batch(c: &mut Criterion) {
     let _ = simple_logger::SimpleLogger::new()
+        .with_utc_timestamps()
         .with_module_level("isahc::agent", log::LevelFilter::Off)
         .with_module_level("tracing::span", log::LevelFilter::Off)
         .with_module_level("tracing::span::active", log::LevelFilter::Off)
@@ -398,6 +399,7 @@ fn batch(c: &mut Criterion) {
 
 fn single_call(c: &mut Criterion) {
     let _ = simple_logger::SimpleLogger::new()
+        .with_utc_timestamps()
         .with_module_level("isahc::agent", log::LevelFilter::Off)
         .with_module_level("tracing::span", log::LevelFilter::Off)
         .with_module_level("tracing::span::active", log::LevelFilter::Off)

--- a/benches/is_enabled.rs
+++ b/benches/is_enabled.rs
@@ -12,7 +12,6 @@ use std::thread;
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use enum_map::Enum;
 use maplit::hashmap;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -21,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use unleash_api_client::api::{Feature, Features, Strategy};
 use unleash_api_client::client;
 use unleash_api_client::context::Context;
+use unleash_api_client::Enum;
 
 // TODO: do a build.rs thing to determine available CPU count at build time for
 // optimal vec sizing.

--- a/examples/async-std.rs
+++ b/examples/async-std.rs
@@ -22,7 +22,9 @@ enum UserFeatures {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let _ = simple_logger::SimpleLogger::new().init();
+    let _ = simple_logger::SimpleLogger::new()
+        .with_utc_timestamps()
+        .init();
     task::block_on(async {
         let config = EnvironmentConfig::from_env()?;
         let client = client::ClientBuilder::default()

--- a/examples/async-std.rs
+++ b/examples/async-std.rs
@@ -8,12 +8,12 @@
 use std::time::Duration;
 
 use async_std::task;
-use enum_map::Enum;
 use futures_timer::Delay;
 use serde::{Deserialize, Serialize};
 
 use unleash_api_client::client;
 use unleash_api_client::config::EnvironmentConfig;
+use unleash_api_client::Enum;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Deserialize, Serialize, Enum, Clone)]

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -23,7 +23,9 @@ enum UserFeatures {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let _ = simple_logger::SimpleLogger::new().init();
+    let _ = simple_logger::SimpleLogger::new()
+        .with_utc_timestamps()
+        .init();
     let config = EnvironmentConfig::from_env()?;
     let client = Arc::new(
         client::ClientBuilder::default()

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -10,11 +10,11 @@ use std::thread;
 use std::time::Duration;
 
 use async_std::task;
-use enum_map::Enum;
 use serde::{Deserialize, Serialize};
 
 use unleash_api_client::client;
 use unleash_api_client::config::EnvironmentConfig;
+use unleash_api_client::Enum;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Deserialize, Serialize, Enum, Clone)]

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -7,12 +7,12 @@
 
 use std::time::Duration;
 
-use enum_map::Enum;
 use futures_timer::Delay;
 use serde::{Deserialize, Serialize};
 
 use unleash_api_client::client;
 use unleash_api_client::config::EnvironmentConfig;
+use unleash_api_client::Enum;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Deserialize, Serialize, Enum, Clone)]

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -22,7 +22,9 @@ enum UserFeatures {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let _ = simple_logger::SimpleLogger::new().init();
+    let _ = simple_logger::SimpleLogger::new()
+        .with_utc_timestamps()
+        .init();
     let config = EnvironmentConfig::from_env()?;
     let client = client::ClientBuilder::default()
         .interval(500)

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use arc_swap::ArcSwapOption;
 use chrono::Utc;
-use enum_map::{Enum, EnumMap};
+use enum_map::EnumMap;
 use futures_timer::Delay;
 use log::{debug, trace, warn};
 use rand::Rng;
@@ -20,6 +20,7 @@ use crate::api::{self, Feature, Features, Metrics, MetricsBucket, Registration};
 use crate::context::Context;
 use crate::http::HTTP;
 use crate::strategy;
+use crate::Enum;
 
 // ----------------- Variant
 
@@ -814,7 +815,6 @@ mod tests {
     use std::default::Default;
     use std::hash::BuildHasher;
 
-    use enum_map::Enum;
     use maplit::hashmap;
     use serde::{Deserialize, Serialize};
 
@@ -822,6 +822,7 @@ mod tests {
     use crate::api::{self, Feature, Features, Strategy};
     use crate::context::{Context, IPAddress};
     use crate::strategy;
+    use crate::Enum;
 
     fn features() -> Features {
         Features {

--- a/src/client.rs
+++ b/src/client.rs
@@ -895,6 +895,7 @@ mod tests {
     #[test]
     fn test_memoization_enum() {
         let _ = simple_logger::SimpleLogger::new()
+            .with_utc_timestamps()
             .with_module_level("isahc::agent", log::LevelFilter::Off)
             .with_module_level("tracing::span", log::LevelFilter::Off)
             .with_module_level("tracing::span::active", log::LevelFilter::Off)
@@ -945,6 +946,7 @@ mod tests {
     #[test]
     fn test_memoization_strs() {
         let _ = simple_logger::SimpleLogger::new()
+            .with_utc_timestamps()
             .with_module_level("isahc::agent", log::LevelFilter::Off)
             .with_module_level("tracing::span", log::LevelFilter::Off)
             .with_module_level("tracing::span::active", log::LevelFilter::Off)
@@ -1007,6 +1009,7 @@ mod tests {
     #[test]
     fn test_custom_strategy() {
         let _ = simple_logger::SimpleLogger::new()
+            .with_utc_timestamps()
             .with_module_level("isahc::agent", log::LevelFilter::Off)
             .with_module_level("tracing::span", log::LevelFilter::Off)
             .with_module_level("tracing::span::active", log::LevelFilter::Off)
@@ -1146,6 +1149,7 @@ mod tests {
     #[test]
     fn variants_enum() {
         let _ = simple_logger::SimpleLogger::new()
+            .with_utc_timestamps()
             .with_module_level("isahc::agent", log::LevelFilter::Off)
             .with_module_level("tracing::span", log::LevelFilter::Off)
             .with_module_level("tracing::span::active", log::LevelFilter::Off)
@@ -1233,6 +1237,7 @@ mod tests {
     #[test]
     fn variants_str() {
         let _ = simple_logger::SimpleLogger::new()
+            .with_utc_timestamps()
             .with_module_level("isahc::agent", log::LevelFilter::Off)
             .with_module_level("tracing::span", log::LevelFilter::Off)
             .with_module_level("tracing::span::active", log::LevelFilter::Off)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! use std::time::Duration;
 //!
 //! use async_std::task;
-//! use enum_map::Enum;
 //! use futures_timer::Delay;
 //! use serde::{Deserialize, Serialize};
 //!
@@ -32,6 +31,7 @@
 //! use unleash_api_client::config::EnvironmentConfig;
 //! use unleash_api_client::context::Context;
 //! use unleash_api_client::strategy;
+//! use unleash_api_client::Enum;
 //!
 //! fn _reversed_uids<S: BuildHasher>(
 //!     parameters: Option<HashMap<String, String, S>>,
@@ -92,6 +92,9 @@ pub mod context;
 pub mod http;
 pub mod strategy;
 
+/// Re-export of enum_map::Enum - this trait is part of our public API.
+pub use enum_map::Enum;
+
 // Exports for ergonomical use
 pub use crate::client::{Client, ClientBuilder};
 pub use crate::config::EnvironmentConfig;
@@ -101,7 +104,6 @@ pub use crate::strategy::Evaluate;
 /// For the complete minimalist
 ///
 /// ```no_run
-/// use enum_map::Enum;
 /// use serde::{Deserialize, Serialize};
 /// use unleash_api_client::prelude::*;
 /// let config = EnvironmentConfig::from_env()?;
@@ -124,4 +126,5 @@ pub use crate::strategy::Evaluate;
 pub mod prelude {
     pub use crate::client::ClientBuilder;
     pub use crate::config::EnvironmentConfig;
+    pub use crate::Enum;
 }

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -25,13 +25,16 @@ mod tests {
     struct Payload {
         #[serde(rename = "type")]
         _type: String,
-        value: String,
+        #[serde(rename = "value")]
+        _value: String,
     }
 
     #[derive(Debug, Deserialize)]
     struct VariantResult {
-        name: String,
-        payload: Option<Payload>,
+        #[serde(rename = "name")]
+        _name: String,
+        #[serde(rename = "payload")]
+        _payload: Option<Payload>,
         enabled: bool,
     }
 
@@ -59,7 +62,8 @@ mod tests {
 
     #[derive(Debug, Deserialize)]
     struct Suite {
-        name: String,
+        #[serde(rename = "name")]
+        _name: String,
         state: api::Features,
         #[serde(flatten)]
         tests: Tests,

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -72,6 +72,7 @@ mod tests {
     fn test_client_specification() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
     {
         let _ = simple_logger::SimpleLogger::new()
+            .with_utc_timestamps()
             .with_module_level("isahc::agent", log::LevelFilter::Off)
             .with_module_level("tracing::span", log::LevelFilter::Off)
             .with_module_level("tracing::span::active", log::LevelFilter::Off)

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -6,10 +6,9 @@ mod tests {
     use std::env;
     use std::fs;
 
-    use enum_map::Enum;
     use serde::{Deserialize, Serialize};
 
-    use unleash_api_client::{api, client, context};
+    use unleash_api_client::{api, client, context, Enum};
 
     #[derive(Debug, Deserialize)]
     struct Test {

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -13,12 +13,11 @@ mod tests {
     use std::time::Duration;
 
     use async_std::task;
-    use enum_map::Enum;
     use futures_timer::Delay;
     use serde::{Deserialize, Serialize};
 
-    use unleash_api_client::client;
     use unleash_api_client::config::EnvironmentConfig;
+    use unleash_api_client::{client, Enum};
 
     #[allow(non_camel_case_types)]
     #[derive(Debug, Deserialize, Serialize, Enum, Clone)]


### PR DESCRIPTION
Export enum_map::Enum as part of our API

This corrects an ergonomic issue for users: they had to match the enum_map version exactly, even if it wasn't the most recent release (and
thus dependabot style updates would error).

Now clients should import Enum from unleash_api_client and will not have  that issue.