### PR TITLE
Make Client::memoize return a thread safe error

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -573,7 +573,7 @@ where
     pub fn memoize(
         &self,
         features: Vec<Feature>,
-    ) -> Result<Option<Metrics>, Box<dyn std::error::Error>> {
+    ) -> Result<Option<Metrics>, Box<dyn std::error::Error + Send + Sync>> {
         let now = Utc::now();
         trace!("memoize: start with {} features", features.len());
         let source_strategies = self.strategies.lock().unwrap();


### PR DESCRIPTION
The `Client::memoize` function currently returns a `Box<dyn std::error::Error>` error, which is not thread safe. I assume that this was a mistake, as every other error type in the crate is `Box<dyn std::error::Error + Send + Sync>` instead.

As a consequence of this, the future returned by `Client::poll_for_updates` is also not thread-safe, which means that it can, for example, not be spawned in a background task with `tokio::spawn`.