### PR TITLE
Bump MSRV

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -10,7 +10,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0 # MSRV
+          - 1.54.0 # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The crate documentation should be consulted for more detail.
 
 ## status
 
-Core Unleash API features work, with Rust 1.51 or above.
+Core Unleash API features work, with Rust 1.54 or above.
 
 Missing Unleash specified features:
 


### PR DESCRIPTION
bumpalo requires 1.54 to build properly.