### PR TITLE
Replace ipaddress dependency with ipnet dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ futures-timer = "3.0.2"
 hostname = "0.3.1"
 http-client = "6.5.1"
 http-types = "2.12.0"
-ipaddress = "0.1.2"
 log = "0.4.14"
 maplit = "1.0.2"
 murmur3 = "0.5.1"
@@ -42,6 +41,7 @@ rand = "0.8.4"
 serde_json = "1.0.68"
 serde_plain = "1.0.0"
 surf = "2.3.1"
+ipnet = "2.3.1"
 
 [dependencies.chrono]
 features = ["serde"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1208,9 +1208,7 @@ mod tests {
             ..Default::default()
         };
         let host1: Context = Context {
-            remote_address: Some(IPAddress(
-                ipaddress::IPAddress::parse("10.10.10.10").unwrap(),
-            )),
+            remote_address: Some(IPAddress("10.10.10.10".parse().unwrap())),
             ..Default::default()
         };
         let variant1 = Variant {
@@ -1285,9 +1283,7 @@ mod tests {
             ..Default::default()
         };
         let host1: Context = Context {
-            remote_address: Some(IPAddress(
-                ipaddress::IPAddress::parse("10.10.10.10").unwrap(),
-            )),
+            remote_address: Some(IPAddress("10.10.10.10".parse().unwrap())),
             ..Default::default()
         };
         let variant1 = Variant {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,12 +1,12 @@
 // Copyright 2020 Cognite AS
 //! <https://docs.getunleash.io/user_guide/unleash_context>
-use std::collections::HashMap;
+use std::{collections::HashMap, net::IpAddr};
 
 use serde::{de, Deserialize};
 
 // Custom IP Address newtype that can be deserialised from strings e.g. 127.0.0.1 for use with tests.
 #[derive(Debug)]
-pub struct IPAddress(pub ipaddress::IPAddress);
+pub struct IPAddress(pub IpAddr);
 
 impl<'de> de::Deserialize<'de> for IPAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -16,7 +16,7 @@ impl<'de> de::Deserialize<'de> for IPAddress {
         if deserializer.is_human_readable() {
             // Deserialize from a human-readable string like "127.0.0.1".
             let s = String::deserialize(deserializer)?;
-            ipaddress::IPAddress::parse(&s)
+            s.parse::<IpAddr>()
                 .map_err(de::Error::custom)
                 .map(IPAddress)
         } else {


### PR DESCRIPTION
The `ipaddress` dependency depends on `num 0.1.42`, which (transitively) depends on `rustc-serialize`, which has a reported vulnerability, [RUSTSEC-2022-0004](https://rustsec.org/advisories/RUSTSEC-2022-0004).

This PR replaces uses of the `ipaddress::IPAddress` type with either `ipnet::IpNet` (when either an IP address or an IP subnet is expected) or `std::net::IpAddr` (when only an IP address is expected).

As a consequence of this, shorthand subnet syntaxes such as `1.2/8` instead of `1.2.0.0/8` will not work, as the `ipnet` crate does not parse these. However, from what I can tell neither does other Unleash clients such as the [node client](https://github.com/Unleash/unleash-client-node), so this should be acceptable.