### PR TITLE
Fix CI pipeline

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -486,7 +486,8 @@ where
         let mut remote_address: Option<String> = None;
         let identifier = context
             .user_id
-            .as_ref().or(context.session_id.as_ref())
+            .as_ref()
+            .or(context.session_id.as_ref())
             .or_else(|| {
                 context.remote_address.as_ref().and_then({
                     |addr| {

--- a/src/client.rs
+++ b/src/client.rs
@@ -486,8 +486,7 @@ where
         let mut remote_address: Option<String> = None;
         let identifier = context
             .user_id
-            .as_ref()
-            .or_else(|| context.session_id.as_ref())
+            .as_ref().or(context.session_id.as_ref())
             .or_else(|| {
                 context.remote_address.as_ref().and_then({
                     |addr| {


### PR DESCRIPTION
Patches the lazy evaulation in the _get_variant call that was causing Clippy to error 