### PR TITLE
Spike for constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ serde_json = "1.0.68"
 serde_plain = "1.0.0"
 surf = "2.3.1"
 semver = "1.0.5"
-str-utils = "0.1.5"
 
 [dependencies.chrono]
 features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1.0.68"
 serde_plain = "1.0.0"
 surf = "2.3.1"
 semver = "1.0.5"
+enum_dispatch = "0.3.8"
 
 [dependencies.chrono]
 features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ rand = "0.8.4"
 serde_json = "1.0.68"
 serde_plain = "1.0.0"
 surf = "2.3.1"
+semver = "1.0.5"
+str-utils = "0.1.5"
 
 [dependencies.chrono]
 features = ["serde"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,135 +9,161 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Features {
-    pub version: u8,
-    pub features: Vec<Feature>,
+  pub version: u8,
+  pub features: Vec<Feature>,
 }
 
 impl Features {
-    pub fn endpoint(api_url: &str) -> String {
-        format!("{}/client/features", api_url)
-    }
+  pub fn endpoint(api_url: &str) -> String {
+    format!("{}/client/features", api_url)
+  }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Feature {
-    pub name: String,
-    #[serde(default)]
-    pub description: String,
-    pub enabled: bool,
-    pub strategies: Vec<Strategy>,
-    pub variants: Option<Vec<Variant>>,
-    #[serde(rename = "createdAt")]
-    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+  pub name: String,
+  #[serde(default)]
+  pub description: String,
+  pub enabled: bool,
+  pub strategies: Vec<Strategy>,
+  pub variants: Option<Vec<Variant>>,
+  #[serde(rename = "createdAt")]
+  pub created_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Strategy {
-    pub constraints: Option<Vec<Constraint>>,
-    pub name: String,
-    pub parameters: Option<HashMap<String, String>>,
+  pub constraints: Option<Vec<Constraint>>,
+  pub name: String,
+  pub parameters: Option<HashMap<String, String>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Constraint {
-    #[serde(rename = "contextName")]
-    pub context_name: String,
-    #[serde(flatten)]
-    pub expression: ConstraintExpression,
+  #[serde(rename = "contextName")]
+  pub context_name: String,
+  #[serde(flatten)]
+  pub expression: ConstraintExpression,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(tag = "operator", content = "values")]
 // #[serde(deny_unknown_fields)]
 pub enum ConstraintExpression {
-    #[serde(rename = "IN")]
-    In(Vec<String>),
-    #[serde(rename = "NOT_IN")]
-    NotIn(Vec<String>),
+  #[serde(rename = "IN")]
+  In(Vec<String>),
+  #[serde(rename = "NOT_IN")]
+  NotIn(Vec<String>),
+  #[serde(rename = "STR_ENDS_WITH")]
+  StrEndsWith(Vec<String>),
+  #[serde(rename = "STR_STARTS_WITH")]
+  StrStartsWith(Vec<String>),
+  #[serde(rename = "STR_CONTAINS")]
+  StrContains(Vec<String>),
+  #[serde(rename = "NUM_EQ")]
+  NumEq(String),
+  #[serde(rename = "NUM_GT")]
+  NumGt(Vec<String>),
+  #[serde(rename = "NUM_GTE")]
+  NumGte(Vec<String>),
+  #[serde(rename = "NUM_LT")]
+  NumLt(Vec<String>),
+  #[serde(rename = "NUM_LTE")]
+  NumLte(Vec<String>),
+  #[serde(rename = "DATE_AFTER")]
+  DateAfter(Vec<String>),
+  #[serde(rename = "DATE_BEFORE")]
+  DateBefore(Vec<String>),
+  #[serde(rename = "SEMVER_EQ")]
+  SemverEq(Vec<String>),
+  #[serde(rename = "SEMVER_GT")]
+  SemverGt(Vec<String>),
+  #[serde(rename = "SEMVER_LT")]
+  SemverLt(Vec<String>),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Variant {
-    pub name: String,
-    pub weight: u8,
-    pub payload: Option<HashMap<String, String>>,
-    pub overrides: Option<Vec<VariantOverride>>,
+  pub name: String,
+  pub weight: u8,
+  pub payload: Option<HashMap<String, String>>,
+  pub overrides: Option<Vec<VariantOverride>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct VariantOverride {
-    #[serde(rename = "contextName")]
-    pub context_name: String,
-    pub values: Vec<String>,
+  #[serde(rename = "contextName")]
+  pub context_name: String,
+  pub values: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Registration {
-    #[serde(rename = "appName")]
-    pub app_name: String,
-    #[serde(rename = "instanceId")]
-    pub instance_id: String,
-    #[serde(rename = "sdkVersion")]
-    pub sdk_version: String,
-    pub strategies: Vec<String>,
-    pub started: chrono::DateTime<chrono::Utc>,
-    pub interval: u64,
+  #[serde(rename = "appName")]
+  pub app_name: String,
+  #[serde(rename = "instanceId")]
+  pub instance_id: String,
+  #[serde(rename = "sdkVersion")]
+  pub sdk_version: String,
+  pub strategies: Vec<String>,
+  pub started: chrono::DateTime<chrono::Utc>,
+  pub interval: u64,
 }
 
 impl Registration {
-    pub fn endpoint(api_url: &str) -> String {
-        format!("{}/client/register", api_url)
-    }
+  pub fn endpoint(api_url: &str) -> String {
+    format!("{}/client/register", api_url)
+  }
 }
 
 impl Default for Registration {
-    fn default() -> Self {
-        Self {
-            app_name: "".into(),
-            instance_id: "".into(),
-            sdk_version: "unleash-client-rust-0.1.0".into(),
-            strategies: vec![],
-            started: Utc::now(),
-            interval: 15 * 1000,
-        }
+  fn default() -> Self {
+    Self {
+      app_name: "".into(),
+      instance_id: "".into(),
+      sdk_version: "unleash-client-rust-0.1.0".into(),
+      strategies: vec![],
+      started: Utc::now(),
+      interval: 15 * 1000,
     }
+  }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Metrics {
-    #[serde(rename = "appName")]
-    pub app_name: String,
-    #[serde(rename = "instanceId")]
-    pub instance_id: String,
-    pub bucket: MetricsBucket,
+  #[serde(rename = "appName")]
+  pub app_name: String,
+  #[serde(rename = "instanceId")]
+  pub instance_id: String,
+  pub bucket: MetricsBucket,
 }
 
 impl Metrics {
-    pub fn endpoint(api_url: &str) -> String {
-        format!("{}/client/metrics", api_url)
-    }
+  pub fn endpoint(api_url: &str) -> String {
+    format!("{}/client/metrics", api_url)
+  }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetricsBucket {
-    pub start: chrono::DateTime<chrono::Utc>,
-    pub stop: chrono::DateTime<chrono::Utc>,
-    /// name: "yes"|"no": count
-    pub toggles: HashMap<String, HashMap<String, u64>>,
+  pub start: chrono::DateTime<chrono::Utc>,
+  pub stop: chrono::DateTime<chrono::Utc>,
+  /// name: "yes"|"no": count
+  pub toggles: HashMap<String, HashMap<String, u64>>,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Registration;
+  use super::Registration;
 
-    #[test]
-    fn parse_reference_doc() -> Result<(), serde_json::Error> {
-        let data = r#"
+  #[test]
+  fn parse_reference_doc() -> Result<(), serde_json::Error> {
+    let data = r#"
     {
       "version": 1,
       "features": [
@@ -209,19 +235,19 @@ mod tests {
       ]
     }
     "#;
-        let parsed: super::Features = serde_json::from_str(data)?;
-        assert_eq!(1, parsed.version);
-        Ok(())
-    }
+    let parsed: super::Features = serde_json::from_str(data)?;
+    assert_eq!(1, parsed.version);
+    Ok(())
+  }
 
-    #[test]
-    fn test_registration_customisation() {
-        Registration {
-            app_name: "test-suite".into(),
-            instance_id: "test".into(),
-            strategies: vec!["default".into()],
-            interval: 5000,
-            ..Default::default()
-        };
-    }
+  #[test]
+  fn test_registration_customisation() {
+    Registration {
+      app_name: "test-suite".into(),
+      instance_id: "test".into(),
+      strategies: vec!["default".into()],
+      interval: 5000,
+      ..Default::default()
+    };
+  }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,10 @@ use std::collections::HashMap;
 use std::default::Default;
 
 use chrono::Utc;
+use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
+
+use crate::{Context, Evaluate};
 
 #[derive(Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
@@ -41,6 +44,60 @@ pub struct Strategy {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum StrConstraint {
+    StrEndsWith(Vec<String>, bool),
+    StrStartsWith(Vec<String>, bool),
+    StrContains(Vec<String>, bool),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum NumericConstraint {
+    NumEq(String),
+    NumGt(String),
+    NumGte(String),
+    NumLt(String),
+    NumLte(String),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum DateConstraint {
+    DateAfter(String),
+    DateBefore(String),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum SemverConstraint {
+    SemverEq(String),
+    SemverGt(String),
+    SemverLt(String),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum ContainsConstraint {
+    In(Vec<String>),
+    NotIn(Vec<String>),
+}
+
+#[enum_dispatch]
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum ConstraintExpression {
+    NumericConstraint,
+    StrConstraint,
+    DateConstraint,
+    SemverConstraint,
+    ContainsConstraint,
+}
+
+#[enum_dispatch(ConstraintExpression)]
+pub trait EvaluatorConstructor {
+    fn yield_evaluator(self, getter: crate::strategy::Expr) -> Evaluate;
+}
+
+pub trait Expression: Fn(&Context) -> Option<&String> {
+    fn clone_boxed(&self) -> Box<dyn Expression + Send + Sync + 'static>;
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Constraint {
     #[serde(rename = "contextName")]
@@ -50,53 +107,53 @@ pub struct Constraint {
     pub expression: ConstraintExpression,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(tag = "operator")]
-// #[serde(deny_unknown_fields)]
-pub enum ConstraintExpression {
-    #[serde(rename = "IN")]
-    In { values: Vec<String> },
-    #[serde(rename = "NOT_IN")]
-    NotIn { values: Vec<String> },
-    #[serde(rename = "STR_ENDS_WITH")]
-    StrEndsWith {
-        values: Vec<String>,
-        #[serde(rename = "caseInsensitive")]
-        case_insensitive: Option<bool>,
-    },
-    #[serde(rename = "STR_STARTS_WITH")]
-    StrStartsWith {
-        values: Vec<String>,
-        #[serde(rename = "caseInsensitive")]
-        case_insensitive: Option<bool>,
-    },
-    #[serde(rename = "STR_CONTAINS")]
-    StrContains {
-        values: Vec<String>,
-        #[serde(rename = "caseInsensitive")]
-        case_insensitive: Option<bool>,
-    },
-    #[serde(rename = "NUM_EQ")]
-    NumEq { value: String },
-    #[serde(rename = "NUM_GT")]
-    NumGt { value: String },
-    #[serde(rename = "NUM_GTE")]
-    NumGte { value: String },
-    #[serde(rename = "NUM_LT")]
-    NumLt { value: String },
-    #[serde(rename = "NUM_LTE")]
-    NumLte { value: String },
-    #[serde(rename = "DATE_AFTER")]
-    DateAfter { value: String },
-    #[serde(rename = "DATE_BEFORE")]
-    DateBefore { value: String },
-    #[serde(rename = "SEMVER_EQ")]
-    SemverEq { value: String },
-    #[serde(rename = "SEMVER_GT")]
-    SemverGt { value: String },
-    #[serde(rename = "SEMVER_LT")]
-    SemverLt { value: String },
-}
+// #[derive(Clone, Serialize, Deserialize, Debug)]
+// #[serde(tag = "operator")]
+// // #[serde(deny_unknown_fields)]
+// pub enum ConstraintExpression {
+//     #[serde(rename = "IN")]
+//     In { values: Vec<String> },
+//     #[serde(rename = "NOT_IN")]
+//     NotIn { values: Vec<String> },
+//     #[serde(rename = "STR_ENDS_WITH")]
+//     StrEndsWith {
+//         values: Vec<String>,
+//         #[serde(rename = "caseInsensitive")]
+//         case_insensitive: Option<bool>,
+//     },
+//     #[serde(rename = "STR_STARTS_WITH")]
+//     StrStartsWith {
+//         values: Vec<String>,
+//         #[serde(rename = "caseInsensitive")]
+//         case_insensitive: Option<bool>,
+//     },
+//     #[serde(rename = "STR_CONTAINS")]
+//     StrContains {
+//         values: Vec<String>,
+//         #[serde(rename = "caseInsensitive")]
+//         case_insensitive: Option<bool>,
+//     },
+//     #[serde(rename = "NUM_EQ")]
+//     NumEq { value: String },
+//     #[serde(rename = "NUM_GT")]
+//     NumGt { value: String },
+//     #[serde(rename = "NUM_GTE")]
+//     NumGte { value: String },
+//     #[serde(rename = "NUM_LT")]
+//     NumLt { value: String },
+//     #[serde(rename = "NUM_LTE")]
+//     NumLte { value: String },
+//     #[serde(rename = "DATE_AFTER")]
+//     DateAfter { value: String },
+//     #[serde(rename = "DATE_BEFORE")]
+//     DateBefore { value: String },
+//     #[serde(rename = "SEMVER_EQ")]
+//     SemverEq { value: String },
+//     #[serde(rename = "SEMVER_GT")]
+//     SemverGt { value: String },
+//     #[serde(rename = "SEMVER_LT")]
+//     SemverLt { value: String },
+// }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -45,44 +45,57 @@ pub struct Strategy {
 pub struct Constraint {
   #[serde(rename = "contextName")]
   pub context_name: String,
+  pub inverted: Option<bool>,
   #[serde(flatten)]
   pub expression: ConstraintExpression,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(tag = "operator", content = "values")]
+#[serde(tag = "operator")]
 // #[serde(deny_unknown_fields)]
 pub enum ConstraintExpression {
   #[serde(rename = "IN")]
-  In(Vec<String>),
+  In { values: Vec<String> },
   #[serde(rename = "NOT_IN")]
-  NotIn(Vec<String>),
+  NotIn { values: Vec<String> },
   #[serde(rename = "STR_ENDS_WITH")]
-  StrEndsWith(Vec<String>),
+  StrEndsWith {
+    values: Vec<String>,
+    #[serde(rename = "caseInsensitive")]
+    case_insensitive: Option<bool>,
+  },
   #[serde(rename = "STR_STARTS_WITH")]
-  StrStartsWith(Vec<String>),
+  StrStartsWith {
+    values: Vec<String>,
+    #[serde(rename = "caseInsensitive")]
+    case_insensitive: Option<bool>,
+  },
   #[serde(rename = "STR_CONTAINS")]
-  StrContains(Vec<String>),
+  StrContains {
+    values: Vec<String>,
+    #[serde(rename = "caseInsensitive")]
+    case_insensitive: Option<bool>,
+  },
   #[serde(rename = "NUM_EQ")]
-  NumEq(String),
+  NumEq { value: String },
   #[serde(rename = "NUM_GT")]
-  NumGt(Vec<String>),
+  NumGt { value: String },
   #[serde(rename = "NUM_GTE")]
-  NumGte(Vec<String>),
+  NumGte { value: String },
   #[serde(rename = "NUM_LT")]
-  NumLt(Vec<String>),
+  NumLt { value: String },
   #[serde(rename = "NUM_LTE")]
-  NumLte(Vec<String>),
+  NumLte { value: String },
   #[serde(rename = "DATE_AFTER")]
-  DateAfter(Vec<String>),
+  DateAfter { value: String },
   #[serde(rename = "DATE_BEFORE")]
-  DateBefore(Vec<String>),
+  DateBefore { value: String },
   #[serde(rename = "SEMVER_EQ")]
-  SemverEq(Vec<String>),
+  SemverEq { value: String },
   #[serde(rename = "SEMVER_GT")]
-  SemverGt(Vec<String>),
+  SemverGt { value: String },
   #[serde(rename = "SEMVER_LT")]
-  SemverLt(Vec<String>),
+  SemverLt { value: String },
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -160,6 +173,38 @@ pub struct MetricsBucket {
 #[cfg(test)]
 mod tests {
   use super::Registration;
+  use super::*;
+
+  #[test]
+  fn parses_advanced_constraint_structure() -> Result<(), serde_json::Error> {
+    let data = r#"
+    {
+      "contextName": "customField",
+      "operator": "STR_STARTS_WITH",
+      "values": ["some-string"]
+    }"#;
+    let _: super::Constraint = serde_json::from_str(data)?;
+
+    let data = r#"
+    {
+      "contextName": "customField",
+      "operator": "NUM_GTE",
+      "value": "7"
+    }"#;
+    let _: super::Constraint = serde_json::from_str(data)?;
+
+    let data = r#"
+    {
+      "contextName": "customField",
+      "operator": "STR_STARTS_WITH",
+      "values": ["some-string"],
+      "caseInsensitive": true,
+      "inverted": true
+    }"#;
+    let _: super::Constraint = serde_json::from_str(data)?;
+
+    Ok(())
+  }
 
   #[test]
   fn parse_reference_doc() -> Result<(), serde_json::Error> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,191 +9,191 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Features {
-  pub version: u8,
-  pub features: Vec<Feature>,
+    pub version: u8,
+    pub features: Vec<Feature>,
 }
 
 impl Features {
-  pub fn endpoint(api_url: &str) -> String {
-    format!("{}/client/features", api_url)
-  }
+    pub fn endpoint(api_url: &str) -> String {
+        format!("{}/client/features", api_url)
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Feature {
-  pub name: String,
-  #[serde(default)]
-  pub description: String,
-  pub enabled: bool,
-  pub strategies: Vec<Strategy>,
-  pub variants: Option<Vec<Variant>>,
-  #[serde(rename = "createdAt")]
-  pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub enabled: bool,
+    pub strategies: Vec<Strategy>,
+    pub variants: Option<Vec<Variant>>,
+    #[serde(rename = "createdAt")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Strategy {
-  pub constraints: Option<Vec<Constraint>>,
-  pub name: String,
-  pub parameters: Option<HashMap<String, String>>,
+    pub constraints: Option<Vec<Constraint>>,
+    pub name: String,
+    pub parameters: Option<HashMap<String, String>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Constraint {
-  #[serde(rename = "contextName")]
-  pub context_name: String,
-  pub inverted: Option<bool>,
-  #[serde(flatten)]
-  pub expression: ConstraintExpression,
+    #[serde(rename = "contextName")]
+    pub context_name: String,
+    pub inverted: Option<bool>,
+    #[serde(flatten)]
+    pub expression: ConstraintExpression,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(tag = "operator")]
 // #[serde(deny_unknown_fields)]
 pub enum ConstraintExpression {
-  #[serde(rename = "IN")]
-  In { values: Vec<String> },
-  #[serde(rename = "NOT_IN")]
-  NotIn { values: Vec<String> },
-  #[serde(rename = "STR_ENDS_WITH")]
-  StrEndsWith {
-    values: Vec<String>,
-    #[serde(rename = "caseInsensitive")]
-    case_insensitive: Option<bool>,
-  },
-  #[serde(rename = "STR_STARTS_WITH")]
-  StrStartsWith {
-    values: Vec<String>,
-    #[serde(rename = "caseInsensitive")]
-    case_insensitive: Option<bool>,
-  },
-  #[serde(rename = "STR_CONTAINS")]
-  StrContains {
-    values: Vec<String>,
-    #[serde(rename = "caseInsensitive")]
-    case_insensitive: Option<bool>,
-  },
-  #[serde(rename = "NUM_EQ")]
-  NumEq { value: String },
-  #[serde(rename = "NUM_GT")]
-  NumGt { value: String },
-  #[serde(rename = "NUM_GTE")]
-  NumGte { value: String },
-  #[serde(rename = "NUM_LT")]
-  NumLt { value: String },
-  #[serde(rename = "NUM_LTE")]
-  NumLte { value: String },
-  #[serde(rename = "DATE_AFTER")]
-  DateAfter { value: String },
-  #[serde(rename = "DATE_BEFORE")]
-  DateBefore { value: String },
-  #[serde(rename = "SEMVER_EQ")]
-  SemverEq { value: String },
-  #[serde(rename = "SEMVER_GT")]
-  SemverGt { value: String },
-  #[serde(rename = "SEMVER_LT")]
-  SemverLt { value: String },
+    #[serde(rename = "IN")]
+    In { values: Vec<String> },
+    #[serde(rename = "NOT_IN")]
+    NotIn { values: Vec<String> },
+    #[serde(rename = "STR_ENDS_WITH")]
+    StrEndsWith {
+        values: Vec<String>,
+        #[serde(rename = "caseInsensitive")]
+        case_insensitive: Option<bool>,
+    },
+    #[serde(rename = "STR_STARTS_WITH")]
+    StrStartsWith {
+        values: Vec<String>,
+        #[serde(rename = "caseInsensitive")]
+        case_insensitive: Option<bool>,
+    },
+    #[serde(rename = "STR_CONTAINS")]
+    StrContains {
+        values: Vec<String>,
+        #[serde(rename = "caseInsensitive")]
+        case_insensitive: Option<bool>,
+    },
+    #[serde(rename = "NUM_EQ")]
+    NumEq { value: String },
+    #[serde(rename = "NUM_GT")]
+    NumGt { value: String },
+    #[serde(rename = "NUM_GTE")]
+    NumGte { value: String },
+    #[serde(rename = "NUM_LT")]
+    NumLt { value: String },
+    #[serde(rename = "NUM_LTE")]
+    NumLte { value: String },
+    #[serde(rename = "DATE_AFTER")]
+    DateAfter { value: String },
+    #[serde(rename = "DATE_BEFORE")]
+    DateBefore { value: String },
+    #[serde(rename = "SEMVER_EQ")]
+    SemverEq { value: String },
+    #[serde(rename = "SEMVER_GT")]
+    SemverGt { value: String },
+    #[serde(rename = "SEMVER_LT")]
+    SemverLt { value: String },
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct Variant {
-  pub name: String,
-  pub weight: u8,
-  pub payload: Option<HashMap<String, String>>,
-  pub overrides: Option<Vec<VariantOverride>>,
+    pub name: String,
+    pub weight: u8,
+    pub payload: Option<HashMap<String, String>>,
+    pub overrides: Option<Vec<VariantOverride>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 // #[serde(deny_unknown_fields)]
 pub struct VariantOverride {
-  #[serde(rename = "contextName")]
-  pub context_name: String,
-  pub values: Vec<String>,
+    #[serde(rename = "contextName")]
+    pub context_name: String,
+    pub values: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Registration {
-  #[serde(rename = "appName")]
-  pub app_name: String,
-  #[serde(rename = "instanceId")]
-  pub instance_id: String,
-  #[serde(rename = "sdkVersion")]
-  pub sdk_version: String,
-  pub strategies: Vec<String>,
-  pub started: chrono::DateTime<chrono::Utc>,
-  pub interval: u64,
+    #[serde(rename = "appName")]
+    pub app_name: String,
+    #[serde(rename = "instanceId")]
+    pub instance_id: String,
+    #[serde(rename = "sdkVersion")]
+    pub sdk_version: String,
+    pub strategies: Vec<String>,
+    pub started: chrono::DateTime<chrono::Utc>,
+    pub interval: u64,
 }
 
 impl Registration {
-  pub fn endpoint(api_url: &str) -> String {
-    format!("{}/client/register", api_url)
-  }
+    pub fn endpoint(api_url: &str) -> String {
+        format!("{}/client/register", api_url)
+    }
 }
 
 impl Default for Registration {
-  fn default() -> Self {
-    Self {
-      app_name: "".into(),
-      instance_id: "".into(),
-      sdk_version: "unleash-client-rust-0.1.0".into(),
-      strategies: vec![],
-      started: Utc::now(),
-      interval: 15 * 1000,
+    fn default() -> Self {
+        Self {
+            app_name: "".into(),
+            instance_id: "".into(),
+            sdk_version: "unleash-client-rust-0.1.0".into(),
+            strategies: vec![],
+            started: Utc::now(),
+            interval: 15 * 1000,
+        }
     }
-  }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Metrics {
-  #[serde(rename = "appName")]
-  pub app_name: String,
-  #[serde(rename = "instanceId")]
-  pub instance_id: String,
-  pub bucket: MetricsBucket,
+    #[serde(rename = "appName")]
+    pub app_name: String,
+    #[serde(rename = "instanceId")]
+    pub instance_id: String,
+    pub bucket: MetricsBucket,
 }
 
 impl Metrics {
-  pub fn endpoint(api_url: &str) -> String {
-    format!("{}/client/metrics", api_url)
-  }
+    pub fn endpoint(api_url: &str) -> String {
+        format!("{}/client/metrics", api_url)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetricsBucket {
-  pub start: chrono::DateTime<chrono::Utc>,
-  pub stop: chrono::DateTime<chrono::Utc>,
-  /// name: "yes"|"no": count
-  pub toggles: HashMap<String, HashMap<String, u64>>,
+    pub start: chrono::DateTime<chrono::Utc>,
+    pub stop: chrono::DateTime<chrono::Utc>,
+    /// name: "yes"|"no": count
+    pub toggles: HashMap<String, HashMap<String, u64>>,
 }
 
 #[cfg(test)]
 mod tests {
-  use super::Registration;
-  use super::*;
+    use super::Registration;
+    use super::*;
 
-  #[test]
-  fn parses_advanced_constraint_structure() -> Result<(), serde_json::Error> {
-    let data = r#"
+    #[test]
+    fn parses_advanced_constraint_structure() -> Result<(), serde_json::Error> {
+        let data = r#"
     {
       "contextName": "customField",
       "operator": "STR_STARTS_WITH",
       "values": ["some-string"]
     }"#;
-    let _: super::Constraint = serde_json::from_str(data)?;
+        let _: super::Constraint = serde_json::from_str(data)?;
 
-    let data = r#"
+        let data = r#"
     {
       "contextName": "customField",
       "operator": "NUM_GTE",
       "value": "7"
     }"#;
-    let _: super::Constraint = serde_json::from_str(data)?;
+        let _: super::Constraint = serde_json::from_str(data)?;
 
-    let data = r#"
+        let data = r#"
     {
       "contextName": "customField",
       "operator": "STR_STARTS_WITH",
@@ -201,14 +201,14 @@ mod tests {
       "caseInsensitive": true,
       "inverted": true
     }"#;
-    let _: super::Constraint = serde_json::from_str(data)?;
+        let _: super::Constraint = serde_json::from_str(data)?;
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn parse_reference_doc() -> Result<(), serde_json::Error> {
-    let data = r#"
+    #[test]
+    fn parse_reference_doc() -> Result<(), serde_json::Error> {
+        let data = r#"
     {
       "version": 1,
       "features": [
@@ -280,19 +280,19 @@ mod tests {
       ]
     }
     "#;
-    let parsed: super::Features = serde_json::from_str(data)?;
-    assert_eq!(1, parsed.version);
-    Ok(())
-  }
+        let parsed: super::Features = serde_json::from_str(data)?;
+        assert_eq!(1, parsed.version);
+        Ok(())
+    }
 
-  #[test]
-  fn test_registration_customisation() {
-    Registration {
-      app_name: "test-suite".into(),
-      instance_id: "test".into(),
-      strategies: vec!["default".into()],
-      interval: 5000,
-      ..Default::default()
-    };
-  }
+    #[test]
+    fn test_registration_customisation() {
+        Registration {
+            app_name: "test-suite".into(),
+            instance_id: "test".into(),
+            strategies: vec!["default".into()],
+            interval: 5000,
+            ..Default::default()
+        };
+    }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,8 +2,8 @@
 //! <https://docs.getunleash.io/user_guide/unleash_context>
 use std::{collections::HashMap, net::IpAddr};
 
-use serde::{de, Deserialize};
 use chrono::Utc;
+use serde::{de, Deserialize};
 
 // Custom IP Address newtype that can be deserialised from strings e.g. 127.0.0.1 for use with tests.
 #[derive(Debug)]
@@ -39,9 +39,10 @@ pub struct Context {
     pub properties: HashMap<String, String>,
     #[serde(default, rename = "appName")]
     pub app_name: String,
+    #[serde(default)]
     pub environment: String,
-    #[serde(default, rename = "currentTime")]
-    pub current_time: String
+    #[serde(default = "current_time", rename = "currentTime")]
+    pub current_time: String,
 }
 
 fn current_time() -> String {

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashMap, net::IpAddr};
 
 use serde::{de, Deserialize};
+use chrono::Utc;
 
 // Custom IP Address newtype that can be deserialised from strings e.g. 127.0.0.1 for use with tests.
 #[derive(Debug)]
@@ -38,6 +39,11 @@ pub struct Context {
     pub properties: HashMap<String, String>,
     #[serde(default, rename = "appName")]
     pub app_name: String,
-    #[serde(default)]
     pub environment: String,
+    #[serde(default, rename = "currentTime")]
+    pub current_time: String
+}
+
+fn current_time() -> String {
+    Utc::now().to_rfc3339()
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -298,6 +298,54 @@ where
                 })
             }
         }
+        ConstraintExpression::StrEndsWith(values) => {
+            if values.is_empty() {
+                Box::new(|_| false)
+            } else {
+                let as_vec: Vec<String> = values.to_vec();
+                Box::new(move |context: &Context| {
+                    getter(context)
+                        .map(|v| as_vec.iter().any(|x| x.starts_with(v)))
+                        .unwrap_or(false)
+                })
+            }
+        }
+        ConstraintExpression::StrStartsWith(values) => {
+            panic!();
+        }
+        ConstraintExpression::StrContains(values) => {
+            panic!()
+        }
+        ConstraintExpression::NumEq(values) => {
+            panic!()
+        }
+        ConstraintExpression::NumGt(values) => {
+            panic!()
+        }
+        ConstraintExpression::NumGte(values) => {
+            panic!()
+        }
+        ConstraintExpression::NumLt(values) => {
+            panic!()
+        }
+        ConstraintExpression::NumLte(values) => {
+            panic!()
+        }
+        ConstraintExpression::DateAfter(values) => {
+            panic!()
+        }
+        ConstraintExpression::DateBefore(values) => {
+            panic!()
+        }
+        ConstraintExpression::SemverEq(values) => {
+            panic!()
+        }
+        ConstraintExpression::SemverGt(values) => {
+            panic!()
+        }
+        ConstraintExpression::SemverLt(values) => {
+            panic!()
+        }
     }
 }
 
@@ -357,6 +405,8 @@ where
                 })
             }
         }
+        // New operators aren't defined for an ip
+        _ => Box::new(move |context: &Context| false),
     }
 }
 

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -377,13 +377,15 @@ where
                 };
                 Box::new(move |context: &Context| {
                     let value = getter(context)
-                        .map(|v| as_vec.iter().any(|x| {
-                            if case_insensitive {
-                                v.to_lowercase().contains(x)
-                            } else {
-                                v.contains(x)
-                            }
-                        }))
+                        .map(|v| {
+                            as_vec.iter().any(|x| {
+                                if case_insensitive {
+                                    v.to_lowercase().contains(x)
+                                } else {
+                                    v.contains(x)
+                                }
+                            })
+                        })
                         .unwrap_or(false);
                     _handle_inversion(&value, &inverted)
                 })

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -296,7 +296,7 @@ where
         }
         ConstraintExpression::NotIn { values } => {
             if values.is_empty() {
-                Box::new(move |_| _handle_inversion(&false, &inverted))
+                Box::new(move |_| _handle_inversion(&true, &inverted))
             } else {
                 let as_set: HashSet<String> = values.iter().cloned().collect();
                 Box::new(move |context: &Context| {

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -93,7 +93,7 @@ mod tests {
             let suite_content = fs::read(spec_dir.join(suite_name))?;
             let suite: Suite = serde_json::from_slice(&suite_content)?;
 
-            assert_eq!(1, suite.state.version);
+            assert!(2 >= suite.state.version);
 
             #[allow(non_camel_case_types)]
             #[derive(Debug, Deserialize, Serialize, Enum, Clone)]


### PR DESCRIPTION
This implements extended support for constraint operators, reference implementation on the node SDK is here: https://github.com/Unleash/unleash-client-node/pull/289/files

Note that the client specs have not been rolled forward to cover these cases, since the specs also include cases for custom stickiness, which isn't as of yet implemented in this SDK, this was covered by local testing against the spec