### PR TITLE
Feat: Preserve original error message in warn! logs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -695,35 +695,48 @@ where
         loop {
             debug!("poll: retrieving features");
             let res = self.http.get(&endpoint).recv_json().await;
-            if let Ok(res) = res {
-                let features: Features = res;
-                match self.memoize(features.features) {
-                    Ok(None) => {}
-                    Ok(Some(metrics)) => {
-                        if !self.disable_metric_submission {
-                            let mut metrics_uploaded = false;
-                            let req = self.http.post(&metrics_endpoint);
-                            if let Ok(body) = http_types::Body::from_json(&metrics) {
-                                let res = req.body(body).await;
-                                if let Ok(res) = res {
-                                    if res.status().is_success() {
-                                        metrics_uploaded = true;
-                                        debug!("poll: uploaded feature metrics")
+            match res {
+                Err(e) => warn!("poll: failed to retrieve features - {:?}", e),
+                Ok(res) => {
+                    let features: Features = res;
+                    match self.memoize(features.features) {
+                        Ok(None) => {}
+                        Ok(Some(metrics)) => {
+                            if !self.disable_metric_submission {
+                                let req = self.http.post(&metrics_endpoint);
+                                match http_types::Body::from_json(&metrics) {
+                                    Err(e) => {
+                                        warn!(
+                                            "poll: error serializing metrics for upload - {:?}",
+                                            e
+                                        );
+                                    }
+                                    Ok(body) => {
+                                        let res = req.body(body).await;
+                                        match res {
+                                            Ok(res) => {
+                                                if res.status().is_success() {
+                                                    debug!("poll: uploaded feature metrics")
+                                                }
+                                            }
+                                            Err(e) => {
+                                                warn!(
+                                                    "poll: error uploading feature metrics - {:?}",
+                                                    e
+                                                );
+                                            }
+                                        }
                                     }
                                 }
                             }
-                            if !metrics_uploaded {
-                                warn!("poll: error uploading feature metrics");
-                            }
+                        }
+                        Err(e) => {
+                            warn!("poll: failed to memoize features - {:?}", e);
                         }
                     }
-                    Err(_) => {
-                        warn!("poll: failed to memoize features");
-                    }
                 }
-            } else {
-                warn!("poll: failed to retrieve features");
             }
+
             let duration = Duration::from_millis(self.interval);
             debug!("poll: waiting {:?}", duration);
             Delay::new(duration).await;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

This PR rearranges the error handling in `poll_for_updates`. It preserves the original error to aid in debugging.

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #35 .

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

Only one file was touched.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

The original code collected whether an error happened in a var that is later checked and logged. I instead embedded the `warn!` calls right where errors happen. I believe this aids in clarity and also means there can be slightly different error messages depending on the situation, but I am open to other ways of handling it as well.
