### PR TITLE
docs: fix errant table formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The values required for the `into_client` method are described as follows (in or
 While the above code shows the usage of the `EnvironmentConfig`, this isn't required and is provided as a convenient way of reading a data from the system environment variables.
 
 EnvironmentConfig Property | Environment Variable | Required? |
----------|-------------|-----------|-------|
+---------|-------------|-----------|
 `api_url`  | `UNLEASH_API_URL`      | Yes |
 `app_name` | `UNLEASH_APP_NAME`     | Yes |
 `instance_id` | `UNLEASH_INSTANCE_ID` | Yes |


### PR DESCRIPTION
This PR fixes a formatting issue with one of the tables in the readme. There was an extra column defined in the separator row, which causes the table to render as text on github and to render with an extra, empty column in the docs.