### PR TITLE
fix: variant weight can be up to `1000`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -63,7 +63,7 @@ pub enum ConstraintExpression {
 #[cfg_attr(feature = "strict", serde(deny_unknown_fields))]
 pub struct Variant {
     pub name: String,
-    pub weight: u8,
+    pub weight: u16,
     pub payload: Option<HashMap<String, String>>,
     pub overrides: Option<Vec<VariantOverride>>,
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->

The weight of the variant can be up to 1000, so `u8` isn't enough. I couldn't find a proper reference, but it's obvious when looking at the code e.g. https://github.com/Unleash/unleash/blob/main/src/lib/routes/admin-api/project/variants.ts#L117.

I don't know when this changed (or if it always was like that) but the client specification seems to be wrong/outdated e.g. here https://github.com/Unleash/client-specification/blob/main/specifications/12-custom-stickiness.json#L24.

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
