### PR TITLE
feat: Add variants metrics to SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ arc-swap = "1.4.0"
 async-std = { version = "1.10.0", optional = true }
 async-trait = "0.1.56"
 cfg-if = "1.0.0"
+dashmap = "5.4.0"
 enum-map = "~2.0.1"
 futures-timer = "3.0.2"
 hostname = "0.3.1"

--- a/benches/is_enabled.rs
+++ b/benches/is_enabled.rs
@@ -242,7 +242,7 @@ fn batch(c: &mut Criterion) {
     );
     let mut group = c.benchmark_group("batch");
     group
-        .throughput(Throughput::Elements(iterations as u64))
+        .throughput(Throughput::Elements(iterations))
         .warm_up_time(Duration::from_secs(15))
         .measurement_time(Duration::from_secs(30));
     group.bench_function("single thread(enum)", |b| {

--- a/src/api.rs
+++ b/src/api.rs
@@ -124,11 +124,18 @@ impl Metrics {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct ToggleMetrics {
+    pub yes: u64,
+    pub no: u64,
+    pub variants: Option<HashMap<String, u64>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct MetricsBucket {
     pub start: chrono::DateTime<chrono::Utc>,
     pub stop: chrono::DateTime<chrono::Utc>,
     /// name: "yes"|"no": count
-    pub toggles: HashMap<String, HashMap<String, u64>>,
+    pub toggles: HashMap<String, ToggleMetrics>,
 }
 
 #[cfg(test)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -134,7 +134,6 @@ pub struct ToggleMetrics {
 pub struct MetricsBucket {
     pub start: chrono::DateTime<chrono::Utc>,
     pub stop: chrono::DateTime<chrono::Utc>,
-    /// name: "yes"|"no": count
     pub toggles: HashMap<String, ToggleMetrics>,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -159,8 +159,8 @@ impl CachedFeature {
     }
 }
 
-impl Into<ToggleMetrics> for &CachedFeature {
-    fn into(self) -> ToggleMetrics {
+impl From<&CachedFeature> for ToggleMetrics {
+    fn from(feature: &CachedFeature) -> Self {
         fn convert_variants_count(original: &DashMap<String, AtomicU64>) -> HashMap<String, u64> {
             let mut cloned_map = HashMap::new();
 
@@ -174,10 +174,10 @@ impl Into<ToggleMetrics> for &CachedFeature {
         }
 
         ToggleMetrics {
-            yes: self.enabled.load(Ordering::Relaxed),
-            no: self.disabled.load(Ordering::Relaxed),
-            variants: if self.variant_metrics.len() > 0 {
-                Some(convert_variants_count(&self.variant_metrics))
+            yes: feature.enabled.load(Ordering::Relaxed),
+            no: feature.disabled.load(Ordering::Relaxed),
+            variants: if !feature.variant_metrics.is_empty() {
+                Some(convert_variants_count(&feature.variant_metrics))
             } else {
                 None
             },
@@ -548,7 +548,7 @@ where
     ) -> Variant {
         if feature.variants.is_empty() {
             trace!("get_variant: feature {:?} no variants", feature_name);
-            feature.count_variant(&"disabled");
+            feature.count_variant("disabled");
             return Variant::disabled();
         }
         let group = format!("{}", feature_name);

--- a/src/client.rs
+++ b/src/client.rs
@@ -1497,7 +1497,7 @@ mod tests {
     }
 
     #[test]
-    fn metrics_serialization() {
+    fn cached_feature_into_toggle_metrics() {
         let variant_counts = [("a", 36), ("b", 16), ("c", 42)];
 
         let variant_metrics = DashMap::new();

--- a/src/client.rs
+++ b/src/client.rs
@@ -162,15 +162,14 @@ impl CachedFeature {
 impl From<&CachedFeature> for ToggleMetrics {
     fn from(feature: &CachedFeature) -> Self {
         fn convert_variants_count(original: &DashMap<String, AtomicU64>) -> HashMap<String, u64> {
-            let mut cloned_map = HashMap::new();
-
-            for reference in original.iter() {
-                let key = reference.key();
-                let value = reference.value();
-                cloned_map.insert(key.clone(), value.load(Ordering::Relaxed));
-            }
-
-            cloned_map
+            original
+                .iter()
+                .map(|item| {
+                    let (key, value) = item.pair();
+                    let count = value.load(Ordering::Relaxed);
+                    (key.clone(), count)
+                })
+                .collect()
         }
 
         ToggleMetrics {
@@ -391,18 +390,14 @@ where
                         fn clone_variants_map(
                             original: &DashMap<String, AtomicU64>,
                         ) -> DashMap<String, AtomicU64> {
-                            let cloned_map = DashMap::new();
-
-                            for reference in original.iter() {
-                                let key = reference.key();
-                                let value = reference.value();
-                                cloned_map.insert(
-                                    key.clone(),
-                                    AtomicU64::new(value.load(Ordering::Relaxed)),
-                                );
-                            }
-
-                            cloned_map
+                            original
+                                .iter()
+                                .map(|item| {
+                                    let (key, value) = item.pair();
+                                    let count = AtomicU64::new(value.load(Ordering::Relaxed));
+                                    (key.clone(), count)
+                                })
+                                .collect()
                         }
 
                         fn cloned_feature(feature: &CachedFeature) -> CachedFeature {

--- a/src/client.rs
+++ b/src/client.rs
@@ -489,7 +489,7 @@ where
             return Variant::disabled();
         }
         let str_f = EnumToString(&feature_enum);
-        self._get_variant(feature, &str_f, context)
+        self._get_variant(feature, str_f, context)
     }
 
     /// Determine what variant (if any) of the feature the given context is
@@ -531,7 +531,7 @@ where
                 );
                 Variant::disabled()
             }
-            Some(feature) => self._get_variant(feature, &feature_name, context),
+            Some(feature) => self._get_variant(feature, feature_name, context),
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -871,7 +871,6 @@ mod tests {
     use std::hash::BuildHasher;
     use std::sync::atomic::{AtomicU64, Ordering};
 
-    use dashmap::DashMap;
     use enum_map::Enum;
     use maplit::hashmap;
     use serde::{Deserialize, Serialize};

--- a/src/client.rs
+++ b/src/client.rs
@@ -158,9 +158,6 @@ impl CachedFeature {
                 self.variants_counts.insert(variant_name.into(), *count + 1);
             }
         };
-        // .and_modify(|count| {        //     *count + 1;
-        // })
-        // .or_insert(1);
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -485,7 +485,6 @@ where
             feature.map(|f| f.count_variant("disabled"));
             return Variant::disabled();
         }
-        let feature = &cache.str_features.get(feature_name);
         match feature {
             None => {
                 trace!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -383,10 +383,12 @@ where
                                 .str_features
                                 .insert(name.clone(), cloned_feature(feature));
                         }
+                        let variants_counts = DashMap::with_capacity(1);
+                        variants_counts.insert("disabled".into(), 1_u64);
                         let stub_feature = CachedFeature {
                             disabled: AtomicU64::new(if default { 0 } else { 1 }),
                             enabled: AtomicU64::new(if default { 1 } else { 0 }),
-                            variants_counts: DashMap::new(),
+                            variants_counts,
                             known: false,
                             feature_disabled: false,
                             strategies: vec![],
@@ -1457,5 +1459,12 @@ mod tests {
         assert_eq!(get_variant_count("two", "variantone"), 1);
 
         assert_eq!(get_variant_count("two", "varianttwo"), 1);
+
+        // Metrics should also be tracked for features that don't exist
+        c.get_variant_str("nonexistant-feature", &Context::default());
+        assert_eq!(get_variant_count("nonexistant-feature", "disabled"), 1);
+
+        c.get_variant_str("nonexistant-feature", &Context::default());
+        assert_eq!(get_variant_count("nonexistant-feature", "disabled"), 2);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1495,10 +1495,10 @@ mod tests {
     fn cached_feature_into_toggle_metrics() {
         let variant_counts = [("a", 36), ("b", 16), ("c", 42)];
 
-        let variant_metrics = DashMap::new();
-        for (variant, count) in variant_counts {
-            variant_metrics.insert(variant.into(), AtomicU64::new(count));
-        }
+        let variant_metrics = variant_counts
+            .iter()
+            .map(|(variant, count)| ((*variant).into(), AtomicU64::new(*count)))
+            .collect();
 
         let yes_count = 85;
         let no_count = 364;


### PR DESCRIPTION
This PR adds support for variant metrics to the Rust SDK. It's about 95 lines of implementation and 150 lines of tests.

Variant metrics should be counted whenever `get_variant` is called:
- if a feature doesn't have variants, register the `disabled` variant
- if a feature is disabled, register the `disabled` variant
- if a feature doesn't exist, it should still register the `disabled` variant.
- otherwise, register the variant that was returned

## Discussion points

I've implemented the variant metrics on each feature instance as a `DashMap` (and thus also added a new crate).
Currently, each feature will get a new DashMap initialized. It gets initialized with a capacity of 0.
It _may_ be worth making the DashMap an Option and only initializing it when it's requested, but that might require a fair 
bit of trickery (and suggestions on how to do it would be very welcome).

### Tests 

I've added tests to ensure that metrics are being counted and that the conversion from CachedFeature to ToggleMetrics works as expected. I've added new tests for these, but the tests for variant counting **could** be added to the existing get_variant tests. However, I felt that would muddy the tests, so I preferred creating new tests.

I have not tested the serde serialization output, because I don't think that would add much value. But I'd be happy to put in a test for that too if you think it would be useful.

### Benches

Of course, benchmarks are a fickle thing, but I figured they'd be useful to make sure there's no giant blunders. Running it locally on my machine against main, I found that most benchmarks have no change or it is within the noise threshold. Three benches indicated performance improved, and three indicated that it had regressed.

Most of the improvements and regressions are =< ~6%, so I don't know how much stock to put in them. However, one regression, `batch/parallel unknown-features(str)` reported a throughput decrease of 24%, so that may be significant.

#### Performance improvements

While I don't see how this would improve performance in any way, the following benches were reported as improved:

```
single_call/single_call(str)
                        time:   [253.58 ns 254.46 ns 255.51 ns]
                        thrpt:  [3.9137 Melem/s 3.9299 Melem/s 3.9435 Melem/s]
                 change:
                        time:   [-3.5225% -2.9598% -2.3842%] (p = 0.00 < 0.05)
                        thrpt:  [+2.4425% +3.0501% +3.6511%]
                        Performance has improved.

batch/parallel distinct-features(enum)
                        time:   [24.728 ms 24.762 ms 24.838 ms]
                        thrpt:  [16.104 Melem/s 16.154 Melem/s 16.176 Melem/s]
                 change:
                        time:   [-6.5260% -5.8273% -5.1205%] (p = 0.00 < 0.05)
                        thrpt:  [+5.3969% +6.1878% +6.9816%]
                        Performance has improved.

batch/parallel unknown-features(enum)
                        time:   [2.9772 ms 2.9899 ms 3.0029 ms]
                        thrpt:  [133.20 Melem/s 133.79 Melem/s 134.35 Melem/s]
                 change:
                        time:   [-6.5641% -6.0584% -5.5674%] (p = 0.00 < 0.05)
                        thrpt:  [+5.8956% +6.4491% +7.0252%]
                        Performance has improved.
```

#### Performance regressions

The following regressions were reported:

```
batch/single thread(str)
                        time:   [12.815 ms 12.892 ms 12.974 ms]
                        thrpt:  [3.8537 Melem/s 3.8783 Melem/s 3.9016 Melem/s]
                 change:
                        time:   [+1.3055% +2.0763% +2.8471%] (p = 0.00 < 0.05)
                        thrpt:  [-2.7683% -2.0341% -1.2887%]
                        Performance has regressed.

batch/parallel same-feature(str)
                        time:   [28.019 ms 28.085 ms 28.170 ms]
                        thrpt:  [14.199 Melem/s 14.242 Melem/s 14.276 Melem/s]
                 change:
                        time:   [+1.2655% +1.8355% +2.4361%] (p = 0.00 < 0.05)
                        thrpt:  [-2.3782% -1.8025% -1.2497%]
                        Performance has regressed.

batch/parallel unknown-features(str)
                        time:   [4.2516 ms 4.2622 ms 4.2794 ms]
                        thrpt:  [93.470 Melem/s 93.849 Melem/s 94.082 Melem/s]
                 change:
                        time:   [+30.189% +31.927% +33.541%] (p = 0.00 < 0.05)
                        thrpt:  [-25.116% -24.200% -23.188%]
                        Performance has regressed.
```