### PR TITLE
feat: track variant metrics

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -148,6 +148,7 @@ pub struct CachedFeature {
 }
 
 impl CachedFeature {
+    #[allow(dead_code)]
     fn variant_metrics(&self) -> HashMap<String, u64> {
         self.variants
             .iter()

--- a/src/client.rs
+++ b/src/client.rs
@@ -142,6 +142,7 @@ pub struct CachedFeature {
     // on submission will be the next logical progression.
     enabled: AtomicU64,
     disabled: AtomicU64,
+    disabled_variant_count: AtomicU64,
     // Variants for use with get_variant
     variants: Vec<api::Variant>,
 }
@@ -352,6 +353,9 @@ where
                             CachedFeature {
                                 disabled: AtomicU64::new(feature.disabled.load(Ordering::Relaxed)),
                                 enabled: AtomicU64::new(feature.enabled.load(Ordering::Relaxed)),
+                                disabled_variant_count: AtomicU64::new(
+                                    feature.disabled_variant_count.load(Ordering::Relaxed),
+                                ),
                                 known: feature.known,
                                 feature_disabled: feature.feature_disabled,
                                 strategies: feature.strategies.clone(),
@@ -369,6 +373,7 @@ where
                         let stub_feature = CachedFeature {
                             disabled: AtomicU64::new(if default { 0 } else { 1 }),
                             enabled: AtomicU64::new(if default { 1 } else { 0 }),
+                            disabled_variant_count: AtomicU64::new(0),
                             known: false,
                             feature_disabled: false,
                             strategies: vec![],
@@ -593,6 +598,7 @@ where
                         strategies,
                         disabled: AtomicU64::new(0),
                         enabled: AtomicU64::new(0),
+                        disabled_variant_count: AtomicU64::new(0),
                         known: true,
                         feature_disabled: true,
                         variants: vec![],
@@ -622,6 +628,7 @@ where
                         strategies,
                         disabled: AtomicU64::new(0),
                         enabled: AtomicU64::new(0),
+                        disabled_variant_count: AtomicU64::new(0),
                         known: true,
                         feature_disabled: false,
                         variants,

--- a/src/client.rs
+++ b/src/client.rs
@@ -518,10 +518,12 @@ where
         let enabled = cache.is_enabled_str(feature_name, Some(context), false, &self.cached_state);
         if !enabled {
             // Count the disabled variant on the newly created, previously missing feature.
-            if let Some(fresh_cache) = self.cached_state().as_ref() { let _ = &fresh_cache
+            if let Some(fresh_cache) = self.cached_state().as_ref() {
+                let _ = &fresh_cache
                     .str_features
                     .get(feature_name)
-                    .map(|f| f.disabled_variant_count.fetch_add(1, Ordering::Relaxed)); }
+                    .map(|f| f.disabled_variant_count.fetch_add(1, Ordering::Relaxed));
+            }
             return Variant::disabled();
         }
         let feature = &cache.str_features.get(feature_name);

--- a/src/client.rs
+++ b/src/client.rs
@@ -516,17 +516,24 @@ where
             Some(cache) => cache,
         };
         let enabled = cache.is_enabled_str(feature_name, Some(context), false, &self.cached_state);
+        let feature = &cache.str_features.get(feature_name);
         if !enabled {
             // Count the disabled variant on the newly created, previously missing feature.
-            if let Some(fresh_cache) = self.cached_state().as_ref() {
-                let _ = &fresh_cache
-                    .str_features
-                    .get(feature_name)
-                    .map(|f| f.disabled_variant_count.fetch_add(1, Ordering::Relaxed));
+            match feature {
+                Some(f) => {
+                    f.disabled_variant_count.fetch_add(1, Ordering::Relaxed);
+                }
+                None => {
+                    if let Some(fresh_cache) = self.cached_state().as_ref() {
+                        let _ = &fresh_cache
+                            .str_features
+                            .get(feature_name)
+                            .map(|f| f.disabled_variant_count.fetch_add(1, Ordering::Relaxed));
+                    }
+                }
             }
             return Variant::disabled();
         }
-        let feature = &cache.str_features.get(feature_name);
         match feature {
             None => {
                 trace!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1535,11 +1535,11 @@ mod tests {
         assert_eq!(variant_count("two", "varianttwo"), 1);
 
         // Metrics should also be tracked for features that don't exist
-        c.get_variant_str("nonexistant-feature", &Context::default());
-        assert_eq!(variant_count("nonexistant-feature", "disabled"), 1);
+        c.get_variant_str("nonexistent-feature", &Context::default());
+        assert_eq!(variant_count("nonexistent-feature", "disabled"), 1);
 
-        c.get_variant_str("nonexistant-feature", &Context::default());
-        assert_eq!(variant_count("nonexistant-feature", "disabled"), 2);
+        c.get_variant_str("nonexistent-feature", &Context::default());
+        assert_eq!(variant_count("nonexistent-feature", "disabled"), 2);
 
         // Calling is_enabled_str shouldn't increment disabled variant counts
         c.is_enabled_str("bogus-feature", None, false);


### PR DESCRIPTION
This PR supersedes #57 and is based on input from @rbtcollins and @sighphyre both in that PR and in a separate conversation in Slack.

## Description

Variant metrics should be counted whenever `get_variant` is called:
- if a feature doesn't have variants, register the `disabled` variant
- if a feature is disabled, register the `disabled` variant
- if a feature doesn't exist, it should still register the `disabled` variant.
- otherwise, register the variant that was returned

This PR implements just the counting of the metrics. It does not implement serialization and submission to Unleash. I'd like to handle that in a follow-up PR after we agree on the implementation of the counting.

## Improvements from #57

This PR has a smaller impact than #57 in two significant ways:
1. It does not introduce any new dependencies
2. It does not negatively affect benchmarks (ran locally)

## Implementation

The disabled variant is counted on the feature level (`CachedFeature`), while each actual variant is counted on the individual variant (`CachedVariant`).

This PR introduces a new `CachedVariant` struct. That struct wraps all the data that exists in `api::Variant` and adds a new `count` property.

Additionally, I've introduced a `variants_metrics` method for the `CachedFeature` struct serializes its variant metrics into hash map.

## Discussion points

### Manual counting of variants

I've left the task of counting variants as a manual job, keeping in line with how `yes` and `no` are counted. We could add an `increment_count` method to the `CachedVariant` struct, but I don't know if it's worth it.

### Benches

Running the benches locally, I see no significant changes between the main branch and this. All differences appear to be within the noise threshold.

The one benchmark that is the most interesting is probably the "batch/parallel unknown-features(str)", which took a pretty significant hit in #57.

Running it with the latest changes in this branch (against main), actually resulted in _improved_ performance. This is probably noise, but it at least seems to indicate that this is fairly safe.
```
batch/parallel unknown-features(str)
                        time:   [3.6369 ms 3.6503 ms 3.6651 ms]
                        thrpt:  [109.14 Melem/s 109.58 Melem/s 109.98 Melem/s]
                 change:
                        time:   [-5.2529% -4.7613% -4.2542%] (p = 0.00 < 0.05)
                        thrpt:  [+4.4433% +4.9994% +5.5441%]
                        Performance has improved.
```