### PR TITLE
feat: serialize variant metrics.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -124,11 +124,17 @@ impl Metrics {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct ToggleMetrics {
+    pub yes: u64,
+    pub no: u64,
+    pub variants: HashMap<String, u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct MetricsBucket {
     pub start: chrono::DateTime<chrono::Utc>,
     pub stop: chrono::DateTime<chrono::Utc>,
-    /// name: "yes"|"no": count
-    pub toggles: HashMap<String, HashMap<String, u64>>,
+    pub toggles: HashMap<String, ToggleMetrics>,
 }
 
 #[cfg(test)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1546,7 +1546,7 @@ mod tests {
             .map(|(name, count)| CachedVariant {
                 count: AtomicU64::from(*count),
                 value: api::Variant {
-                    name: name.clone().into(),
+                    name: (*name).into(),
                     weight: 0,
                     payload: None,
                     overrides: None,


### PR DESCRIPTION
Building on #60, this PR serializes the variant metrics that we store,
so that they get sent together with the other metrics.

The implementation uses a new `ToggleMetrics` struct because we now
have more structure to the metrics. I've also implemented
`From<&CachedFeature> for ToggleMetrics` to make put the conversion in
one place and to write a test for it.