### PR TITLE
Release: bump version to 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "unleash-api-client"
 readme = "README.md"
 repository = "https://github.com/cognitedata/unleash-client-rust/"
 rust-version = "1.59"
-version = "0.8.1"
+version = "0.8.2"
 
 [badges]
 [badges.maintenance]


### PR DESCRIPTION
This is intended to release the fix for variant weighting that we recently introduced in e700231.
