### PR TITLE
feat: implement semver strategy constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ log = "0.4.14"
 murmur3 = "0.5.1"
 rand = "0.8.4"
 rustversion = "1.0.7"
+semver = "1.0.18"
 serde_json = "1.0.68"
 serde_plain = "1.0.0"
 surf = { version = "2.3.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ UNLEASH_API_URL=http://127.0.0.1:4242/api \
 
 or similar. The functional test suite looks for a manually setup set of
 features. E.g. log into the Unleash UI on port 4242 and create a feature called
-`default`.
+`default` & `semver` with a `SEMVER_EQ` strategy constraint with `app_name` value of `1.0.0`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   web:
-    image: unleashorg/unleash-server:4.12.6
+    image: unleashorg/unleash-server:4.16.0
     ports:
       - "4242:4242"
     environment:

--- a/src/api.rs
+++ b/src/api.rs
@@ -50,13 +50,29 @@ pub struct Constraint {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(tag = "operator", content = "values")]
+#[serde(tag = "operator")]
 #[cfg_attr(feature = "strict", serde(deny_unknown_fields))]
 pub enum ConstraintExpression {
     #[serde(rename = "IN")]
-    In(Vec<String>),
+    In(MultiValueExpression),
     #[serde(rename = "NOT_IN")]
-    NotIn(Vec<String>),
+    NotIn(MultiValueExpression),
+    #[serde(rename = "SEMVER_EQ")]
+    SemverEq(SingleValueExpression),
+    #[serde(rename = "SEMVER_GT")]
+    SemverGt(SingleValueExpression),
+    #[serde(rename = "SEMVER_LT")]
+    SemverLt(SingleValueExpression),
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct MultiValueExpression {
+    pub values: Vec<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct SingleValueExpression {
+    pub value: String,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -19,6 +19,7 @@ mod tests {
     use futures_timer::Delay;
     use serde::{Deserialize, Serialize};
 
+    use unleash_api_client::Context;
     use unleash_api_client::{client, config::EnvironmentConfig, http::HttpClient};
 
     #[cfg(not(any(feature = "surf", feature = "reqwest")))]
@@ -28,6 +29,7 @@ mod tests {
     #[derive(Debug, Deserialize, Serialize, Enum, Clone)]
     enum UserFeatures {
         default,
+        semver
     }
 
     #[async_trait]
@@ -120,6 +122,8 @@ mod tests {
             // Ensure we have features
             Delay::new(Duration::from_millis(500)).await;
             assert!(client.is_enabled(UserFeatures::default, None, false));
+            assert!(client.is_enabled(UserFeatures::semver, Some(&Context { app_name: "1.0.0".to_string(), ..Context::default() }), false));
+            assert!(!client.is_enabled(UserFeatures::semver, Some(&Context { app_name: "1.0.1".to_string(), ..Context::default() }), false));
             // Ensure the metrics get up-loaded
             Delay::new(Duration::from_millis(500)).await;
             client.stop_poll().await;
@@ -179,7 +183,7 @@ mod tests {
         A::sleep(Duration::from_millis(500)).await;
         assert!(client.is_enabled(UserFeatures::default, None, false));
         // Ensure the metrics get up-loaded
-        A::sleep(Duration::from_millis(500));
+        let _ = A::sleep(Duration::from_millis(500));
         client.stop_poll().await;
 
         handler.await;


### PR DESCRIPTION
## About the changes
Implements semver based strategy constraints.

<!-- Does it close an issue? Multiple? -->
Closes https://github.com/Unleash/unleash-client-rust/issues/64
Closes https://github.com/Unleash/unleash-client-rust/issues/35

There a re a bunch of other constraints still not implemented, that should be trivial to add in a followup. For now, this PR has a bit more logic due to the semver constraint using the "value" field instead of "values" which requires serde to be aware of that. 

Edit: I see there is a ~1 year old PR (https://github.com/Unleash/unleash-client-rust/pull/27) that implements constraints as well. Wondering what's up with that.

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
