### PR TITLE
Update null feature parsing logic

### DIFF
--- a/benches/is_enabled.rs
+++ b/benches/is_enabled.rs
@@ -172,7 +172,7 @@ where
         // once for enums, once for strings
         let name = format!("Flexible{}", i);
         features.push(Feature {
-            description: name.clone(),
+            description: Some(name.clone()),
             enabled: true,
             created_at: None,
             variants: None,
@@ -186,7 +186,7 @@ where
         });
         let name = format!("flexible{}", i);
         features.push(Feature {
-            description: name.clone(),
+            description: Some(name.clone()),
             enabled: true,
             created_at: None,
             variants: None,

--- a/src/api.rs
+++ b/src/api.rs
@@ -24,7 +24,7 @@ impl Features {
 pub struct Feature {
     pub name: String,
     #[serde(default)]
-    pub description: String,
+    pub description: Option<String>,
     pub enabled: bool,
     pub strategies: Vec<Strategy>,
     pub variants: Option<Vec<Variant>>,
@@ -211,6 +211,35 @@ mod tests {
         ],
         "variants": null,
         "createdAt": "2020-03-17T01:07:25.713Z"
+      }
+      ]
+    }
+    "#;
+        let parsed: super::Features = serde_json::from_str(data)?;
+        assert_eq!(1, parsed.version);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_null_feature_doc() -> Result<(), serde_json::Error> {
+        let data = r#"
+    {
+      "version": 1,
+      "features": [
+      {
+        "name": "F1",
+        "description": null,
+        "enabled": false,
+        "strategies": [
+        {
+          "name": "default"
+        }
+        ],
+        "variants":[
+        {"name":"Foo","weight":50,"payload":{"type":"string","value":"bar"}},
+        {"name":"Bar","weight":50,"overrides":[{"contextName":"userId","values":["robert"]}]}
+        ],
+        "createdAt": "2020-04-28T07:26:27.366Z"
       }
       ]
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -922,7 +922,7 @@ mod tests {
             version: 1,
             features: vec![
                 Feature {
-                    description: "default".into(),
+                    description: Some("default".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,
@@ -933,7 +933,7 @@ mod tests {
                     }],
                 },
                 Feature {
-                    description: "userWithId".into(),
+                    description: Some("userWithId".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,
@@ -945,7 +945,7 @@ mod tests {
                     }],
                 },
                 Feature {
-                    description: "userWithId+default".into(),
+                    description: Some("userWithId+default".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,
@@ -963,7 +963,7 @@ mod tests {
                     ],
                 },
                 Feature {
-                    description: "disabled".into(),
+                    description: Some("disabled".to_string()),
                     enabled: false,
                     created_at: None,
                     variants: None,
@@ -974,7 +974,7 @@ mod tests {
                     }],
                 },
                 Feature {
-                    description: "nostrategies".into(),
+                    description: Some("nostrategies".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,
@@ -1122,7 +1122,7 @@ mod tests {
             version: 1,
             features: vec![
                 Feature {
-                    description: "default".into(),
+                    description: Some("default".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,
@@ -1133,7 +1133,7 @@ mod tests {
                     }],
                 },
                 Feature {
-                    description: "reversed".into(),
+                    description: Some("reversed".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,
@@ -1169,7 +1169,7 @@ mod tests {
             version: 1,
             features: vec![
                 Feature {
-                    description: "disabled".into(),
+                    description: Some("disabled".to_string()),
                     enabled: false,
                     created_at: None,
                     variants: None,
@@ -1177,7 +1177,7 @@ mod tests {
                     strategies: vec![],
                 },
                 Feature {
-                    description: "novariants".into(),
+                    description: Some("novariants".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,
@@ -1188,7 +1188,7 @@ mod tests {
                     }],
                 },
                 Feature {
-                    description: "one".into(),
+                    description: Some("one".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: Some(vec![api::Variant {
@@ -1203,7 +1203,7 @@ mod tests {
                     strategies: vec![],
                 },
                 Feature {
-                    description: "two".into(),
+                    description: Some("two".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: Some(vec![
@@ -1228,7 +1228,7 @@ mod tests {
                     strategies: vec![],
                 },
                 Feature {
-                    description: "nostrategies".into(),
+                    description: Some("nostrategies".to_string()),
                     enabled: true,
                     created_at: None,
                     variants: None,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
I was trying out Unleashed for the first time (product is awesome!) but noticed features would never become enabled in the Rust client. I noticed if I only had features with descriptions things _did_ work, and tracked it down to the poller failing to parse the features from json. Not relevant to the Rust sdk but it does seem like if you create a new feature and don't give a description, the field is `null` in the json response, but if you create it with a description but then erase the description and save it, it returns `""` instead of `null`.

In any case, the `description` field on a `feature` can be `null` - when it is `null` it fails to parse since it's represented by a `String` in the Rust representation.

The obvious way to fix this would be just changing `description: String` to `description: Option<String>`, but it does seem like it was intentional since there are other optional fields and it has a `#[serde(default)]` attribute. Maybe someone has some more context on that?

The default serde attribute isn't enough in this case because it doesn't apply when the field is present, but set to null, it only applies if the field isn't given at all.

Assuming it was intentional to not make the description optional, this parser should turn an incoming `description: null` into `description: ""`.

I added a test that fails before this change but passes afterward.

<!-- Does it close an issue? Multiple? -->


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
If it wasn't intentional to make the description _not_ optional we can go that route instead and just make it optional. I think there's some more work to do there since there is other code that assumes the field will be `String` and not `Option<String>`, but happy to do that work if that's the route we want to go.
