### PR TITLE
Release: bump version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "unleash-api-client"
 readme = "README.md"
 repository = "https://github.com/cognitedata/unleash-client-rust/"
 rust-version = "1.59"
-version = "0.8.2"
+version = "0.9.0"
 
 [badges]
 [badges.maintenance]


### PR DESCRIPTION
This bumps the version of the SDK to include the fix for feature descriptions added in #66.

Because the `Feature` struct is a `pub` struct, this becomes a breaking change, so I've bumped the minor version as we're before 1.0.