### PR TITLE
Allow minor changes in `enum-map`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ arc-swap = "1.4.0"
 async-std = { version = "1.10.0", optional = true }
 async-trait = "0.1.56"
 cfg-if = "1.0.0"
-enum-map = "2.0.1"
+enum-map = "2.6.3"
 futures-timer = "3.0.2"
 hostname = "0.3.1"
 ipnet = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ arc-swap = "1.4.0"
 async-std = { version = "1.10.0", optional = true }
 async-trait = "0.1.56"
 cfg-if = "1.0.0"
-enum-map = "~2.0.1"
+enum-map = "2.0.1"
 futures-timer = "3.0.2"
 hostname = "0.3.1"
 ipnet = "2.3.1"


### PR DESCRIPTION
## About the changes
Replace the `~` with the default `^` so to unlock minor updates in `enum-map`.
The minor being lock may be too strict (?) and might (and in fact does) prevent users from updating their dependencies.

## Discussion points
It compiles, but I am unsure about the reason for locking the minor in the first place.
Introduced here https://github.com/Unleash/unleash-client-rust/commit/b7bd91f3190300f747b21a3b88789b1a8d1ce410#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R46
