### PR TITLE
Release: bump version to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "unleash-api-client"
 readme = "README.md"
 repository = "https://github.com/cognitedata/unleash-client-rust/"
 rust-version = "1.59"
-version = "0.9.0"
+version = "0.10.0"
 
 [badges]
 [badges.maintenance]


### PR DESCRIPTION
This bumps the version of the SDK to 0.10.0, releasing the recent [fix for variant distribution](https://github.com/Unleash/unleash-client-rust/pull/69).

Because this changes how the hashing works, it also changes some of the existing results. This requires a minor version update since we're pre-1.0.
