### PR TITLE
chore: replace `chrono` with `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,10 +59,10 @@ serde_json = "1.0.68"
 serde_plain = "1.0.0"
 surf = { version = "2.3.1", optional = true }
 
-[dependencies.chrono]
+[dependencies.time]
 default-features = false
-features = ["clock", "serde"]
-version = "0.4.19"
+features = ["std", "serde"]
+version = "0.3.30"
 
 [dependencies.reqwest]
 default-features = false

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::default::Default;
 
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -29,7 +28,7 @@ pub struct Feature {
     pub strategies: Vec<Strategy>,
     pub variants: Option<Vec<Variant>>,
     #[serde(rename = "createdAt")]
-    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub created_at: Option<time::OffsetDateTime>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, Debug)]
@@ -85,7 +84,7 @@ pub struct Registration {
     #[serde(rename = "sdkVersion")]
     pub sdk_version: String,
     pub strategies: Vec<String>,
-    pub started: chrono::DateTime<chrono::Utc>,
+    pub started: time::OffsetDateTime,
     pub interval: u64,
 }
 
@@ -102,7 +101,7 @@ impl Default for Registration {
             instance_id: "".into(),
             sdk_version: "unleash-client-rust-0.1.0".into(),
             strategies: vec![],
-            started: Utc::now(),
+            started: time::OffsetDateTime::now_utc(),
             interval: 15 * 1000,
         }
     }
@@ -132,8 +131,8 @@ pub struct ToggleMetrics {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetricsBucket {
-    pub start: chrono::DateTime<chrono::Utc>,
-    pub stop: chrono::DateTime<chrono::Utc>,
+    pub start: time::OffsetDateTime,
+    pub stop: time::OffsetDateTime,
     pub toggles: HashMap<String, ToggleMetrics>,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use arc_swap::ArcSwapOption;
-use chrono::Utc;
 use enum_map::{EnumArray, EnumMap};
 use futures_timer::Delay;
 use log::{debug, trace, warn};
@@ -202,7 +201,7 @@ pub struct CachedState<F>
 where
     F: EnumArray<CachedFeature>,
 {
-    start: chrono::DateTime<chrono::Utc>,
+    start: time::OffsetDateTime,
     // user supplies F defining the features they need
     // The default value of F is defined as 'fallback to string lookups'.
     features: EnumMap<F, CachedFeature>,
@@ -668,7 +667,7 @@ where
         &self,
         features: Vec<Feature>,
     ) -> Result<Option<Metrics>, Box<dyn std::error::Error + Send + Sync>> {
-        let now = Utc::now();
+        let now = time::OffsetDateTime::now_utc();
         trace!("memoize: start with {} features", features.len());
         let source_strategies = self.strategies.lock().unwrap();
         let mut unenumerated_features: HashMap<String, CachedFeature> = HashMap::new();


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

We've replaced all usage of `chrono` with `time` (which `chrono` originally was designed to supersede) at work - pulling in `unleash-client` bloated our lockfiles again 😅 

We find the API easier to use, and the lowered compile times/fewer dependencies is an added bonus

<!-- Does it close an issue? Multiple? -->
N/A

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

N/A

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

Does this need to be feature gated? I guess it does since `MetricsBucket.start/end` are `pub` and accessible via `client.memoize`'s `bucket`.

But in case you're not interested in this change, I thought to open up a PR early.