### PR TITLE
Log deserialization error on poll.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -777,10 +777,8 @@ where
         self.polling.store(true, Ordering::Relaxed);
         loop {
             debug!("poll: retrieving features");
-            let res = self.http.get_json(&endpoint).await;
-            if let Ok(res) = res {
-                let features: Features = res;
-                match self.memoize(features.features) {
+            match self.http.get_json::<Features>(&endpoint).await {
+                Ok(features) => match self.memoize(features.features) {
                     Ok(None) => {}
                     Ok(Some(metrics)) => {
                         if !self.disable_metric_submission {
@@ -797,12 +795,13 @@ where
                             }
                         }
                     }
-                    Err(_) => {
-                        warn!("poll: failed to memoize features");
+                    Err(err) => {
+                        warn!("poll: failed to memoize features: {:?}", err);
                     }
+                },
+                Err(err) => {
+                    warn!("poll: failed to retrieve features: {:?}", err);
                 }
-            } else {
-                warn!("poll: failed to retrieve features");
             }
 
             let duration = Duration::from_millis(self.interval);


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
I was debugging some strange feature polling errors in log which occurred to be JSON deserialization error, but it was not clear until I logged error message.
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
Should there be some tolerance to deserialization errors? It is occurred that the problem I've got is some deeply nested object declared "variant" in once case to be a string storing number in JSON like:
```
{"name":"xxx","weight":"0","payload":{"type":"string","value":"2"}
```
Which is occurred to be not a problem to Java's SDK which rely on GSON:
<img width="922" alt="Screenshot 2024-01-03 at 23 22 52" src="https://github.com/Unleash/unleash-client-rust/assets/385639/349276c1-e573-490a-b2ac-3da75c2ed103">

Such deserialization is by default is not supported by serde and require additional work [like this](https://docs.rs/serde-aux/latest/serde_aux/field_attributes/fn.deserialize_number_from_string.html)
