### PR TITLE
Limit feature metrics

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -749,6 +749,16 @@ where
                     feature.into(),
                 );
             }
+            // Only create metrics for used str_features.
+            if self.enable_str_features {
+                for (name, feature) in &old.str_features {
+                    if feature.enabled.load(Ordering::Relaxed) != 0
+                        || feature.disabled.load(Ordering::Relaxed) != 0
+                    {
+                        bucket.toggles.insert(name.clone(), feature.into());
+                    }
+                }
+            }
             let metrics = Metrics {
                 app_name: self.app_name.clone(),
                 instance_id: self.instance_id.clone(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -749,9 +749,6 @@ where
                     feature.into(),
                 );
             }
-            for (name, feature) in &old.str_features {
-                bucket.toggles.insert(name.clone(), feature.into());
-            }
             let metrics = Metrics {
                 app_name: self.app_name.clone(),
                 instance_id: self.instance_id.clone(),


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Currently, the SDK attempts to upload metrics for every single feature that exsits on the server, regardless if they have been used or not. This results in a possibly gigantic payload, which can become too big to upload.

<!-- Does it close an issue? Multiple? -->
Closes #75

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I'm not completely sure that this is the best way to check if a feature is being used/has been requested, but it does seem a pretty good proxy.
That `.load(Ordering::Relaxed)` is very much a guess for a good way to do it; I'm not familiar with using `AtomicU64` .