### PR TITLE
Fix double slash in url.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -15,7 +15,7 @@ pub struct Features {
 
 impl Features {
     pub fn endpoint(api_url: &str) -> String {
-        format!("{}/client/features", api_url)
+        format!("{}/client/features", api_url.trim_end_matches('/'))
     }
 }
 
@@ -92,7 +92,7 @@ pub struct Registration {
 
 impl Registration {
     pub fn endpoint(api_url: &str) -> String {
-        format!("{}/client/register", api_url)
+        format!("{}/client/register", api_url.trim_end_matches('/'))
     }
 }
 
@@ -120,7 +120,7 @@ pub struct Metrics {
 
 impl Metrics {
     pub fn endpoint(api_url: &str) -> String {
-        format!("{}/client/metrics", api_url)
+        format!("{}/client/metrics", api_url.trim_end_matches('/'))
     }
 }
 
@@ -159,7 +159,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::Registration;
+
+    use super::{Features, Metrics, Registration};
 
     #[test]
     fn parse_reference_doc() -> Result<(), serde_json::Error> {
@@ -288,5 +289,35 @@ mod tests {
             interval: 5000,
             ..Default::default()
         };
+    }
+
+    #[test]
+    fn test_endpoints_handle_trailing_slashes() {
+        assert_eq!(
+            Registration::endpoint("https://localhost:4242/api"),
+            "https://localhost:4242/api/client/register"
+        );
+        assert_eq!(
+            Registration::endpoint("https://localhost:4242/api/"),
+            "https://localhost:4242/api/client/register"
+        );
+
+        assert_eq!(
+            Features::endpoint("https://localhost:4242/api"),
+            "https://localhost:4242/api/client/features"
+        );
+        assert_eq!(
+            Features::endpoint("https://localhost:4242/api/"),
+            "https://localhost:4242/api/client/features"
+        );
+
+        assert_eq!(
+            Metrics::endpoint("https://localhost:4242/api"),
+            "https://localhost:4242/api/client/metrics"
+        );
+        assert_eq!(
+            Metrics::endpoint("https://localhost:4242/api/"),
+            "https://localhost:4242/api/client/metrics"
+        );
     }
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
It was unclear whether it was expected by user that provided API url is end with `/` or not. I've actually passed URL with trailing `/`, which ended up inability to register client. It wen't unnoticed until deployed on prod, because there was different URL.
<img width="1113" alt="image" src="https://github.com/Unleash/unleash-client-rust/assets/385639/bee639dc-aa24-4b40-92ce-1414ed4d6439">
I've made a change to make SDK tolerate URLs ended with `/` by trimming user-provided URL before concatenation with rest of endpoint.

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
