### PR TITLE
release: bump version to 0.10.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "unleash-api-client"
 readme = "README.md"
 repository = "https://github.com/cognitedata/unleash-client-rust/"
 rust-version = "1.59"
-version = "0.10.1"
+version = "0.10.2"
 
 [badges]
 [badges.maintenance]


### PR DESCRIPTION
Includes the fix for allowing trailing slashes in URLs.