### PR TITLE
Update reqwest dependency to v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 name = "unleash-api-client"
 readme = "README.md"
 repository = "https://github.com/cognitedata/unleash-client-rust/"
-rust-version = "1.59"
+rust-version = "1.63"
 version = "0.10.3"
 
 [badges]
@@ -68,7 +68,7 @@ version = "0.4.19"
 default-features = false
 features = ["json"]
 optional = true
-version = "0.12.0"
+version = "0.12.1"
 
 [dependencies.serde]
 features = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ version = "0.4.19"
 default-features = false
 features = ["json"]
 optional = true
-version = "0.11.10"
+version = "0.12.0"
 
 [dependencies.serde]
 features = ["derive"]


### PR DESCRIPTION
With Reqwest 0.12 out, this is needed to allow library users to provide their own reqwest 0.12 client.

for example, we had
```rust
let client = client::ClientBuilder::default()
    .into_client::<UserFeatures, reqwest::Client>(&api_url, app_name, &instance_id, secret)
```

Which was no longer working once we upgraded to reqwest 0.12.