### PR TITLE
fix: bump patch version of the publish-action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,12 +24,12 @@ jobs:
           cache-name: cache-publish-action
         with:
           path: ~/.cargo
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-v0.1.13
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v0.1.16
 
       # install publish-action by cargo in github action
       - name: Install publish-action
         if: steps.cache-publish-action.outputs.cache-hit != 'true'
-        run: cargo install publish-action --version=0.1.13
+        run: cargo install publish-action --version=0.1.16
 
       - name: Run publish-action
         run: publish-action


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Publish action stopped working: https://github.com/Unleash/unleash-client-rust/actions/runs/13494621300/job/37699027353

I'm bumping up the patch version of the publish action. I'm also considering updating it by the minor version to 0.4.0 (https://crates.io/crates/publish-action/versions). To verify the publish action we need to merge this change to main.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
