### PR TITLE
[feat]: Support missing constraint expressions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "client-specification"]
 	path = client-specification
-	url = https://github.com/ikezedev/client-specification
-	branch = ike/rust-client-update
+	url = https://github.com/Unleash/client-specification
+	branch = client-spec-rust-sdk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "client-specification"]
 	path = client-specification
-	url = https://github.com/Unleash/client-specification
+	url = https://github.com/ikezedev/client-specification
+	branch = ike/rust-client-update

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1851,19 +1851,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.193"
+name = "semver"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1969,9 +1978,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2207,6 +2227,7 @@ dependencies = [
  "reqwest 0.11.18",
  "reqwest 0.12.4",
  "rustversion",
+ "semver",
  "serde",
  "serde_json",
  "serde_plain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ log = "0.4.14"
 murmur3 = "0.5.1"
 rand = "0.9.1"
 rustversion = "1.0.7"
+semver = { version = "1.0.26", features = ["serde"] }
 serde_json = "1.0.68"
 serde_plain = "1.0.0"
 uuid = { version = "1.11.0", features = ["v4"] }
@@ -63,7 +64,7 @@ optional = true
 package = "reqwest"
 
 [dependencies.serde]
-version = "1.0"
+version = "1.0.219"
 features = ["derive"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unleash-api-client"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Robert Collins <robert.collins@cognite.com>"]
 edition = "2021"
 rust-version = "1.74"

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,6 +7,7 @@ use crate::version::get_sdk_version;
 use chrono::{DateTime, Utc};
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "strict", serde(deny_unknown_fields))]
@@ -74,27 +75,27 @@ pub enum ConstraintExpression {
     #[serde(rename = "NUM_EQ")]
     NumEq {
         #[serde(deserialize_with = "deserialize_number_from_string")]
-        value: usize,
+        value: f64,
     },
     #[serde(rename = "NUM_GT")]
     NumGT {
         #[serde(deserialize_with = "deserialize_number_from_string")]
-        value: usize,
+        value: f64,
     },
     #[serde(rename = "NUM_GTE")]
     NumGTE {
         #[serde(deserialize_with = "deserialize_number_from_string")]
-        value: usize,
+        value: f64,
     },
     #[serde(rename = "NUM_LT")]
     NumLT {
         #[serde(deserialize_with = "deserialize_number_from_string")]
-        value: usize,
+        value: f64,
     },
     #[serde(rename = "NUM_LTE")]
     NumLTE {
         #[serde(deserialize_with = "deserialize_number_from_string")]
-        value: usize,
+        value: f64,
     },
 
     // Semver
@@ -112,6 +113,9 @@ pub enum ConstraintExpression {
     StrStartsWith { values: Vec<String> },
     #[serde(rename = "STR_ENDS_WITH")]
     StrEndsWith { values: Vec<String> },
+
+    #[serde(untagged)]
+    Unknown(Value),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -416,13 +420,13 @@ mod tests {
                     context_name: "remoteAddress".to_string(),
                     case_insensitive: Some(false,),
                     inverted: Some(false,),
-                    expression: NumGTE { value: 3333 },
+                    expression: NumGTE { value: 3333.0 },
                 },
                 Constraint {
                     context_name: "appId".to_string(),
                     case_insensitive: Some(false,),
                     inverted: Some(false,),
-                    expression: NumEq { value: 888 },
+                    expression: NumEq { value: 888.0 },
                 },
                 Constraint {
                     context_name: "appId".to_string(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 use std::default::Default;
 
 use crate::version::get_sdk_version;
-use chrono::Utc;
+use chrono::{DateTime, FixedOffset, Utc};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -54,10 +55,45 @@ pub struct Constraint {
 #[serde(tag = "operator", content = "values")]
 #[cfg_attr(feature = "strict", serde(deny_unknown_fields))]
 pub enum ConstraintExpression {
+    //. Dates
+    #[serde(rename = "DATE_AFTER")]
+    DateAfter(DateTime<FixedOffset>),
+    #[serde(rename = "DATE_BEFORE")]
+    DateBefore(DateTime<FixedOffset>),
+
+    // In
     #[serde(rename = "IN")]
     In(Vec<String>),
     #[serde(rename = "NOT_IN")]
     NotIn(Vec<String>),
+
+    // Numbers
+    #[serde(rename = "NUM_EQ")]
+    NumEq(String),
+    #[serde(rename = "NUM_GT")]
+    NumGT(String),
+    #[serde(rename = "NUM_GTE")]
+    NumGTE(String),
+    #[serde(rename = "NUM_LT")]
+    NumLT(String),
+    #[serde(rename = "NUM_LTE")]
+    NumLTE(String),
+
+    // Semver
+    #[serde(rename = "SEMVER_EQ")]
+    SemverEq(Version),
+    #[serde(rename = "SEMVER_GT")]
+    SemverGT(Version),
+    #[serde(rename = "SEMVER_LT")]
+    SemverLT(Version),
+
+    // String
+    #[serde(rename = "STR_CONTAINS")]
+    StrContains(Vec<String>),
+    #[serde(rename = "STR_STARTS_WITH")]
+    StrStartsWith(Vec<String>),
+    #[serde(rename = "STR_ENDS_WITH")]
+    StrEndsWith(Vec<String>),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -44,35 +44,38 @@ pub struct Strategy {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Constraint {
-    #[serde(rename = "contextName")]
     pub context_name: String,
-    #[serde(rename = "caseInsensitive")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub case_insensitive: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub inverted: Option<bool>,
+    #[serde(default)]
+    pub case_insensitive: bool,
+    #[serde(default)]
+    pub inverted: bool,
     #[serde(flatten)]
     pub expression: ConstraintExpression,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "operator")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ConstraintExpression {
     // Dates
-    #[serde(rename = "DATE_AFTER")]
-    DateAfter { value: DateTime<Utc> },
-    #[serde(rename = "DATE_BEFORE")]
-    DateBefore { value: DateTime<Utc> },
+    DateAfter {
+        value: DateTime<Utc>,
+    },
+    DateBefore {
+        value: DateTime<Utc>,
+    },
 
     // In
-    #[serde(rename = "IN")]
-    In { values: Vec<String> },
-    #[serde(rename = "NOT_IN")]
-    NotIn { values: Vec<String> },
+    In {
+        values: Vec<String>,
+    },
+    NotIn {
+        values: Vec<String>,
+    },
 
     // Numbers
-    #[serde(rename = "NUM_EQ")]
     NumEq {
         #[serde(deserialize_with = "deserialize_number_from_string")]
         value: f64,
@@ -99,20 +102,28 @@ pub enum ConstraintExpression {
     },
 
     // Semver
-    #[serde(rename = "SEMVER_EQ")]
-    SemverEq { value: Version },
+    SemverEq {
+        value: Version,
+    },
     #[serde(rename = "SEMVER_GT")]
-    SemverGT { value: Version },
+    SemverGT {
+        value: Version,
+    },
     #[serde(rename = "SEMVER_LT")]
-    SemverLT { value: Version },
+    SemverLT {
+        value: Version,
+    },
 
     // String
-    #[serde(rename = "STR_CONTAINS")]
-    StrContains { values: Vec<String> },
-    #[serde(rename = "STR_STARTS_WITH")]
-    StrStartsWith { values: Vec<String> },
-    #[serde(rename = "STR_ENDS_WITH")]
-    StrEndsWith { values: Vec<String> },
+    StrContains {
+        values: Vec<String>,
+    },
+    StrStartsWith {
+        values: Vec<String>,
+    },
+    StrEndsWith {
+        values: Vec<String>,
+    },
 
     #[serde(untagged)]
     Unknown(Value),
@@ -400,16 +411,16 @@ mod tests {
             vec![
                 Constraint {
                     context_name: "appId".to_string(),
-                    case_insensitive: Some(false,),
-                    inverted: Some(false,),
+                    case_insensitive: false,
+                    inverted: false,
                     expression: In {
                         values: vec!["app.known.name".to_string(),],
                     },
                 },
                 Constraint {
                     context_name: "currentTime".to_string(),
-                    case_insensitive: Some(false,),
-                    inverted: Some(false,),
+                    case_insensitive: false,
+                    inverted: false,
                     expression: DateAfter {
                         value: DateTime::<FixedOffset>::parse_from_rfc3339("2025-07-17T23:59:00Z")
                             .unwrap()
@@ -418,20 +429,20 @@ mod tests {
                 },
                 Constraint {
                     context_name: "remoteAddress".to_string(),
-                    case_insensitive: Some(false,),
-                    inverted: Some(false,),
+                    case_insensitive: false,
+                    inverted: false,
                     expression: NumGTE { value: 3333.0 },
                 },
                 Constraint {
                     context_name: "appId".to_string(),
-                    case_insensitive: Some(false,),
-                    inverted: Some(false,),
+                    case_insensitive: false,
+                    inverted: false,
                     expression: NumEq { value: 888.0 },
                 },
                 Constraint {
                     context_name: "appId".to_string(),
-                    case_insensitive: Some(false,),
-                    inverted: Some(false,),
+                    case_insensitive: false,
+                    inverted: false,
                     expression: SemverEq {
                         value: Version::from_str("1.2.3").unwrap(),
                     },

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::default::Default;
 
 use crate::version::get_sdk_version;
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, Utc};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
@@ -57,9 +57,9 @@ pub struct Constraint {
 pub enum ConstraintExpression {
     //. Dates
     #[serde(rename = "DATE_AFTER")]
-    DateAfter(DateTime<FixedOffset>),
+    DateAfter(DateTime<Utc>),
     #[serde(rename = "DATE_BEFORE")]
-    DateBefore(DateTime<FixedOffset>),
+    DateBefore(DateTime<Utc>),
 
     // In
     #[serde(rename = "IN")]

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,7 @@ impl<'de> de::Deserialize<'de> for IPAddress {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Context {
     #[serde(rename = "userId")]
@@ -42,6 +42,21 @@ pub struct Context {
     pub app_name: String,
     #[serde(default)]
     pub environment: String,
-    #[serde(rename = "currentTime")]
-    pub current_time: Option<DateTime<Utc>>,
+    /// Defaults to the current time.
+    #[serde(rename = "currentTime", default = "Utc::now")]
+    pub current_time: DateTime<Utc>,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Context {
+            user_id: Default::default(),
+            session_id: Default::default(),
+            remote_address: Default::default(),
+            properties: Default::default(),
+            app_name: Default::default(),
+            environment: Default::default(),
+            current_time: Utc::now(),
+        }
+    }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,9 @@
 // Copyright 2020 Cognite AS
 //! <https://docs.getunleash.io/user_guide/unleash_context>
+use chrono::Utc;
 use std::{collections::HashMap, net::IpAddr};
 
+use chrono::DateTime;
 use serde::{de, Deserialize};
 
 // Custom IP Address newtype that can be deserialised from strings e.g. 127.0.0.1 for use with tests.
@@ -40,4 +42,6 @@ pub struct Context {
     pub app_name: String,
     #[serde(default)]
     pub environment: String,
+    #[serde(rename = "currentTime")]
+    pub current_time: Option<DateTime<Utc>>,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -37,7 +37,7 @@ pub struct Context {
     #[serde(rename = "remoteAddress")]
     pub remote_address: Option<IPAddress>,
     #[serde(default)]
-    pub properties: HashMap<String, String>,
+    pub properties: HashMap<String, Option<String>>,
     #[serde(default, rename = "appName")]
     pub app_name: String,
     #[serde(default)]
@@ -45,6 +45,12 @@ pub struct Context {
     /// Defaults to the current time.
     #[serde(rename = "currentTime", default = "Utc::now")]
     pub current_time: DateTime<Utc>,
+}
+
+impl Context {
+    pub fn get_property(&self, prop_key: &str) -> Option<&String> {
+        self.properties.get(prop_key).into_iter().flatten().next()
+    }
 }
 
 impl Default for Context {

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -321,13 +321,13 @@ where
     F: Fn(&Context) -> Option<&String> + Clone + Sync + Send + 'static,
 {
     match &expression {
-        ConstraintExpression::In(values) => {
+        ConstraintExpression::In { values } => {
             let as_set: HashSet<String> = values.iter().cloned().collect();
             Box::new(move |context: &Context| {
                 getter(context).map(|v| as_set.contains(v)).unwrap_or(false)
             })
         }
-        ConstraintExpression::NotIn(values) => {
+        ConstraintExpression::NotIn { values } => {
             if values.is_empty() {
                 Box::new(|_| true)
             } else {
@@ -339,13 +339,13 @@ where
                 })
             }
         }
-        ConstraintExpression::StrContains(values) => {
+        ConstraintExpression::StrContains { values } => {
             let as_set: HashSet<String> = values.iter().cloned().collect();
             Box::new(move |context: &Context| {
                 getter(context).map(|v| as_set.contains(v)).unwrap_or(false)
             })
         }
-        ConstraintExpression::StrStartsWith(values) => {
+        ConstraintExpression::StrStartsWith { values } => {
             let as_vec: Vec<String> = values.iter().cloned().collect();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -353,7 +353,7 @@ where
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::StrEndsWith(values) => {
+        ConstraintExpression::StrEndsWith { values } => {
             let as_vec: Vec<String> = values.iter().cloned().collect();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -361,57 +361,52 @@ where
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::NumEq(value) => {
-            let as_num = str::parse::<usize>(&value).ok();
+        ConstraintExpression::NumEq { value } => {
+            let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
                     .and_then(|v| str::parse::<usize>(v).ok())
-                    .zip(as_num)
-                    .map(|(ctx_v, val)| ctx_v == val)
+                    .map(|v| v == value)
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::NumGT(value) => {
-            let as_num = str::parse::<usize>(&value).ok();
+        ConstraintExpression::NumGT { value } => {
+            let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
                     .and_then(|v| str::parse::<usize>(v).ok())
-                    .zip(as_num)
-                    .map(|(ctx_v, val)| ctx_v > val)
+                    .map(|v| v > value)
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::NumGTE(value) => {
-            let as_num = str::parse::<usize>(&value).ok();
+        ConstraintExpression::NumGTE { value } => {
+            let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
                     .and_then(|v| str::parse::<usize>(v).ok())
-                    .zip(as_num)
-                    .map(|(ctx_v, val)| ctx_v >= val)
+                    .map(|v| v >= value)
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::NumLT(value) => {
-            let as_num = str::parse::<usize>(&value).ok();
+        ConstraintExpression::NumLT { value } => {
+            let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
                     .and_then(|v| str::parse::<usize>(v).ok())
-                    .zip(as_num)
-                    .map(|(ctx_v, val)| ctx_v < val)
+                    .map(|v| v < value)
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::NumLTE(value) => {
-            let as_num = str::parse::<usize>(&value).ok();
+        ConstraintExpression::NumLTE { value } => {
+            let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
                     .and_then(|v| str::parse::<usize>(v).ok())
-                    .zip(as_num)
-                    .map(|(ctx_v, val)| ctx_v <= val)
+                    .map(|v| v <= value)
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::SemverEq(value) => {
+        ConstraintExpression::SemverEq { value } => {
             let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -420,7 +415,7 @@ where
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::SemverGT(value) => {
+        ConstraintExpression::SemverGT { value } => {
             let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -429,7 +424,7 @@ where
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::SemverLT(value) => {
+        ConstraintExpression::SemverLT { value } => {
             let value = value.clone();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -448,11 +443,11 @@ where
     F: Fn(&Context) -> Option<&DateTime<Utc>> + Clone + Sync + Send + 'static,
 {
     match &expression {
-        ConstraintExpression::DateAfter(value) => {
+        ConstraintExpression::DateAfter { value } => {
             let value = value.clone();
             Box::new(move |context: &Context| getter(context).map(|v| *v > value).unwrap_or(false))
         }
-        ConstraintExpression::DateBefore(value) => {
+        ConstraintExpression::DateBefore { value } => {
             let value = value.clone();
             Box::new(move |context: &Context| getter(context).map(|v| *v < value).unwrap_or(false))
         }
@@ -479,7 +474,7 @@ where
     F: Fn(&Context) -> Option<&crate::context::IPAddress> + Clone + Sync + Send + 'static,
 {
     match &expression {
-        ConstraintExpression::In(values) => {
+        ConstraintExpression::In { values } => {
             let ips = _ip_to_vec(values);
             Box::new(move |context: &Context| {
                 getter(context)
@@ -494,7 +489,7 @@ where
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::NotIn(values) => {
+        ConstraintExpression::NotIn { values } => {
             if values.is_empty() {
                 Box::new(|_| false)
             } else {
@@ -516,7 +511,7 @@ where
                 })
             }
         }
-        ConstraintExpression::StrContains(values) => {
+        ConstraintExpression::StrContains { values } => {
             let as_set: HashSet<String> = values.iter().cloned().collect();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -527,7 +522,7 @@ where
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::StrStartsWith(values) => {
+        ConstraintExpression::StrStartsWith { values } => {
             let as_vec: Vec<String> = values.iter().cloned().collect();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -538,7 +533,7 @@ where
                     .unwrap_or(false)
             })
         }
-        ConstraintExpression::StrEndsWith(values) => {
+        ConstraintExpression::StrEndsWith { values } => {
             let as_vec: Vec<String> = values.iter().cloned().collect();
             Box::new(move |context: &Context| {
                 getter(context)
@@ -639,6 +634,15 @@ mod tests {
         Some(IPAddress(addr.parse().unwrap()))
     }
 
+    fn default_constraint() -> Constraint {
+        Constraint {
+            context_name: "".into(),
+            case_insensitive: None,
+            inverted: None,
+            expression: ConstraintExpression::In { values: vec![] },
+        }
+    }
+
     #[test]
     fn test_constrain() {
         // Without constraints, things should just pass through
@@ -659,7 +663,8 @@ mod tests {
         assert!(!super::constrain(
             Some(vec![Constraint {
                 context_name: "".into(),
-                expression: ConstraintExpression::In(vec![]),
+                expression: ConstraintExpression::In { values: vec![] },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -673,7 +678,10 @@ mod tests {
         assert!(!super::constrain(
             Some(vec![Constraint {
                 context_name: "environment".into(),
-                expression: ConstraintExpression::In(vec!["development".into()]),
+                expression: ConstraintExpression::In {
+                    values: vec!["development".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -687,7 +695,10 @@ mod tests {
         assert!(!super::constrain(
             Some(vec![Constraint {
                 context_name: "environment".into(),
-                expression: ConstraintExpression::NotIn(vec!["development".into()]),
+                expression: ConstraintExpression::NotIn {
+                    values: vec!["development".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -701,7 +712,10 @@ mod tests {
         assert!(super::constrain(
             Some(vec![Constraint {
                 context_name: "environment".into(),
-                expression: ConstraintExpression::In(vec!["development".into()]),
+                expression: ConstraintExpression::In {
+                    values: vec!["development".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -714,7 +728,10 @@ mod tests {
         assert!(super::constrain(
             Some(vec![Constraint {
                 context_name: "environment".into(),
-                expression: ConstraintExpression::In(vec!["staging".into(), "development".into()]),
+                expression: ConstraintExpression::In {
+                    values: vec!["staging".into(), "development".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -728,10 +745,10 @@ mod tests {
         assert!(super::constrain(
             Some(vec![Constraint {
                 context_name: "environment".into(),
-                expression: ConstraintExpression::NotIn(vec![
-                    "staging".into(),
-                    "development".into()
-                ]),
+                expression: ConstraintExpression::NotIn {
+                    values: vec!["staging".into(), "development".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -747,7 +764,10 @@ mod tests {
         assert!(super::constrain(
             Some(vec![Constraint {
                 context_name: "userId".into(),
-                expression: ConstraintExpression::In(vec!["fred".into()]),
+                expression: ConstraintExpression::In {
+                    values: vec!["fred".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -761,7 +781,10 @@ mod tests {
         assert!(super::constrain(
             Some(vec![Constraint {
                 context_name: "sessionId".into(),
-                expression: ConstraintExpression::In(vec!["qwerty".into()]),
+                expression: ConstraintExpression::In {
+                    values: vec!["qwerty".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -775,7 +798,10 @@ mod tests {
         assert!(super::constrain(
             Some(vec![Constraint {
                 context_name: "remoteAddress".into(),
-                expression: ConstraintExpression::In(vec!["10.0.0.0/8".into()]),
+                expression: ConstraintExpression::In {
+                    values: vec!["10.0.0.0/8".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -787,7 +813,10 @@ mod tests {
         assert!(super::constrain(
             Some(vec![Constraint {
                 context_name: "remoteAddress".into(),
-                expression: ConstraintExpression::NotIn(vec!["10.0.0.0/8".into()]),
+                expression: ConstraintExpression::NotIn {
+                    values: vec!["10.0.0.0/8".into()]
+                },
+                ..default_constraint()
             }]),
             &super::default,
             None
@@ -803,11 +832,17 @@ mod tests {
             Some(vec![
                 Constraint {
                     context_name: "environment".into(),
-                    expression: ConstraintExpression::In(vec!["development".into()]),
+                    expression: ConstraintExpression::In {
+                        values: vec!["development".into()]
+                    },
+                    ..default_constraint()
                 },
                 Constraint {
                     context_name: "environment".into(),
-                    expression: ConstraintExpression::In(vec!["development".into()]),
+                    expression: ConstraintExpression::In {
+                        values: vec!["development".into()]
+                    },
+                    ..default_constraint()
                 },
             ]),
             &super::default,
@@ -817,11 +852,15 @@ mod tests {
             Some(vec![
                 Constraint {
                     context_name: "environment".into(),
-                    expression: ConstraintExpression::In(vec!["development".into()]),
+                    expression: ConstraintExpression::In {
+                        values: vec!["development".into()]
+                    },
+                    ..default_constraint()
                 },
                 Constraint {
                     context_name: "environment".into(),
-                    expression: ConstraintExpression::In(vec![]),
+                    expression: ConstraintExpression::In { values: vec![] },
+                    ..default_constraint()
                 }
             ]),
             &super::default,

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -547,7 +547,7 @@ where
             })
         }
         ConstraintExpression::StrStartsWith { values } => {
-            let as_vec: Vec<String> = values.iter().cloned().collect();
+            let as_vec: Vec<String> = values.to_vec();
             Box::new(move |context: &Context| {
                 let result = getter(context)
                     .map(|v| v.0)
@@ -558,7 +558,7 @@ where
             })
         }
         ConstraintExpression::StrEndsWith { values } => {
-            let as_vec: Vec<String> = values.iter().cloned().collect();
+            let as_vec: Vec<String> = values.to_vec();
             Box::new(move |context: &Context| {
                 let result = getter(context)
                     .map(|v| v.0)

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -110,7 +110,7 @@ mod tests {
         let suite_names: Vec<String> = serde_json::from_slice(&index)?;
         for suite_name in suite_names {
             log::info!("Running suite {suite_name}");
-            let suite_content = fs::read(spec_dir.join(suite_name))?;
+            let suite_content = fs::read(spec_dir.join(&suite_name))?;
             let suite: Suite =
                 serde_json::from_slice(&suite_content).map_err(|err| err.to_string())?;
 

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -64,15 +64,11 @@ mod tests {
     }
 
     #[derive(Debug, Deserialize)]
-    #[serde(untagged)]
     enum Tests {
-        Tests {
-            tests: Vec<Test>,
-        },
-        VariantTests {
-            #[serde(rename = "variantTests")]
-            variant_tests: Vec<VariantTest>,
-        },
+        #[serde(rename = "tests")]
+        Tests(Vec<Test>),
+        #[serde(rename = "variantTests")]
+        VariantTests(Vec<VariantTest>),
     }
 
     #[derive(Debug, Deserialize)]
@@ -115,7 +111,8 @@ mod tests {
         for suite_name in suite_names {
             log::info!("Running suite {suite_name}");
             let suite_content = fs::read(spec_dir.join(suite_name))?;
-            let suite: Suite = serde_json::from_slice(&suite_content)?;
+            let suite: Suite =
+                serde_json::from_slice(&suite_content).map_err(|err| err.to_string())?;
 
             assert_eq!(1, suite.state.version);
 
@@ -135,26 +132,27 @@ mod tests {
             c.memoize(suite.state.features).unwrap();
 
             match suite.tests {
-                Tests::Tests { tests } => {
+                Tests::Tests(tests) => {
                     for test in tests {
                         assert_eq!(
                             test.expected_result,
                             c.is_enabled_str(&test.toggle_name, Some(&test.context), false),
-                            "Test '{}' failed: got {} instead of {}",
+                            "Test '{}' in suite '{}' failed: got {} instead of {}",
                             test.description,
+                            suite_name,
                             !test.expected_result,
                             test.expected_result
                         );
                     }
                 }
-                Tests::VariantTests { variant_tests } => {
+                Tests::VariantTests(variant_tests) => {
                     for test in variant_tests {
                         let result = c.get_variant_str(&test.toggle_name, &test.context);
 
                         assert_eq!(
                             test.expected_result, result,
-                            "Test '{}' failed: got {:?} instead of {:?}",
-                            test.description, result, test.expected_result
+                            "Test '{}' in suite '{}' failed: got {:?} instead of {:?}",
+                            test.description, suite_name, result, test.expected_result
                         );
                     }
                 }

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -114,8 +114,6 @@ mod tests {
             let suite: Suite =
                 serde_json::from_slice(&suite_content).map_err(|err| err.to_string())?;
 
-            assert_eq!(1, suite.state.version);
-
             #[allow(non_camel_case_types)]
             #[derive(Debug, Deserialize, Serialize, Enum, Clone)]
             enum NoFeatures {}

--- a/tests/clientspec.rs
+++ b/tests/clientspec.rs
@@ -111,8 +111,7 @@ mod tests {
         for suite_name in suite_names {
             log::info!("Running suite {suite_name}");
             let suite_content = fs::read(spec_dir.join(&suite_name))?;
-            let suite: Suite =
-                serde_json::from_slice(&suite_content).map_err(|err| err.to_string())?;
+            let suite: Suite = serde_json::from_slice(&suite_content)?;
 
             #[allow(non_camel_case_types)]
             #[derive(Debug, Deserialize, Serialize, Enum, Clone)]


### PR DESCRIPTION
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Currently the client fails to load feature toggles when a new constraint that is currently not supported is created on the unleash dashboard. This has a wide reaching side effect as even valid feature flags would be disabled. In this PR, we try to support all the constraints used by unleash and not break when a new one we do not know is added.

- Feat: support STR_CONTAINS, STR_STARTS_WITH and STR_ENDS_WITH
- Feat: support DATE_AFTER and DATE_BEFORE
- Feat: support SEMVER_EQ, SEMVER_GT and SEMVER_LT
- Feat: support NUM_EQ, NUM_GT, NUM_GTE, NUM_LT and NUM_LTE 
- Feat: support `inverted` and `caseInsensitive` in constraints
- Fix: Warn on unknown or invalid constraint expression instead of failing
- Add unit tests for new constraint expression variants
- Pass additional client specification tests — 3 new test suites passing (NB: test 12 was skipped as it requires a feature that is too big to implemented in this PR)

<!-- Does it close an issue? Multiple? -->
Closes #65, #97 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
- src/strategy.rs
- src/api.rs
