### PR TITLE
feat: add support for `reqwest` v0.13

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -14,6 +14,7 @@ jobs:
           # no need for reqwest-client-rustls, it changes only internals of reqwest
           - reqwest-client
           - reqwest-client-11
+          - reqwest-client-13
 
     steps:
       - uses: actions/checkout@v2
@@ -58,13 +59,13 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features strict,async-std,reqwest-client,reqwest-client-rustls,reqwest-client-11,reqwest-client-11-rustls --all-targets
+          args: --features strict,async-std,reqwest-client,reqwest-client-rustls,reqwest-client-11,reqwest-client-11-rustls,reqwest-client-13 --all-targets
 
       - uses: actions-rs/cargo@v1
         # We test with approximately all-features to ensure that that does build
         with:
           command: test
-          args: --features strict,async-std,reqwest-client,reqwest-client-rustls,reqwest-client-11,reqwest-client-11-rustls --all-targets
+          args: --features strict,async-std,reqwest-client,reqwest-client-rustls,reqwest-client-11,reqwest-client-11-rustls,reqwest-client-13 --all-targets
 
       - uses: actions-rs/cargo@v1
         with:
@@ -74,7 +75,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features strict,async-std,reqwest-client,reqwest-client-rustls,reqwest-client-11,reqwest-client-11-rustls --all-targets -- -D warnings
+          args: --features strict,async-std,reqwest-client,reqwest-client-rustls,reqwest-client-11,reqwest-client-11-rustls,reqwest-client-13 --all-targets -- -D warnings
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,13 @@ features = ["json"]
 optional = true
 package = "reqwest"
 
+[dependencies.reqwest-13]
+version = "0.13"
+default-features = false
+features = ["json"]
+optional = true
+package = "reqwest"
+
 [dependencies.serde]
 version = "1.0.219"
 features = ["derive"]
@@ -97,6 +104,7 @@ functional = []
 # Built in HTTP clients
 reqwest-client = ["reqwest", "reqwest?/default-tls"]
 reqwest-client-11 = ["reqwest-11", "reqwest-11?/default-tls"]
+reqwest-client-13 = ["reqwest-13", "reqwest-13?/default-tls"]
 # For users that don't want to depend on OpenSSL.
 reqwest-client-11-rustls = ["reqwest-11", "reqwest-11?/rustls-tls"]
 reqwest-client-rustls = ["reqwest", "reqwest?/rustls-tls"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unleash API client for Rustlang
 
-[Unleash](https://docs.getunleash.io) is a private, secure, and scalable [feature management platform](https://www.getunleash.io/) built to reduce the risk of releasing new features and accelerate software development. This Rust SDK is designed to help you integrate with Unleash and evaluate feature flags in Rust programs.
+[Unleash](https://docs.getunleash.io) is a private, secure, and scalable [feature management platform](https://www.getunleash.io/) built to reduce the risk of releasing new features and accelerate software development. This Rust SDK is designed to help you integrate with Unleash and evaluate feature flags in Rust programs.
 
 You can use this client with [Unleash Enterprise](https://www.getunleash.io/pricing?utm_source=readme&utm_medium=rust) or [Unleash Open Source](https://github.com/Unleash/unleash).
 
@@ -11,8 +11,8 @@ surf or reqwest support is built in, or any async HTTP client can be provided by
 the user if they implement the thin trait used to abstract over the actual
 client.
 
-Examples with async-std (feature 'surf-client') and tokio (feature
-'reqwest-client') are in the examples/ in the source tree. See the API docs for
+Examples with async-std (feature `surf-client`) and tokio (feature
+`reqwest-client`) are in the examples/ in the source tree. See the API docs for
 more feature information.
 
 To use it in a sync program, run an async executor and `block_on()` the relevant

--- a/src/client.rs
+++ b/src/client.rs
@@ -614,6 +614,8 @@ mod tests {
             use reqwest::Client as HttpClient;
         } else if #[cfg(feature = "reqwest-11")] {
             use reqwest_11::Client as HttpClient;
+        } else if #[cfg(feature = "reqwest-13")] {
+            use reqwest_13::Client as HttpClient;
         } else {
             compile_error!("Cannot run test suite without a client enabled");
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,6 +5,8 @@
 mod reqwest;
 #[cfg(feature = "reqwest-11")]
 mod reqwest_11;
+#[cfg(feature = "reqwest-13")]
+mod reqwest_13;
 mod shim;
 
 pub struct HTTP<C: HttpClient> {

--- a/src/http/reqwest_13.rs
+++ b/src/http/reqwest_13.rs
@@ -1,0 +1,48 @@
+//! Shim reqwest into an unleash HTTP client
+
+// Copyright 2022 Cognite AS
+
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+
+use super::HttpClient;
+
+#[async_trait]
+impl HttpClient for reqwest_13::Client {
+    type HeaderName = reqwest_13::header::HeaderName;
+    type Error = reqwest_13::Error;
+    type RequestBuilder = reqwest_13::RequestBuilder;
+
+    fn build_header(name: &'static str) -> Result<Self::HeaderName, Self::Error> {
+        Ok(Self::HeaderName::from_static(name))
+    }
+
+    fn get(&self, uri: &str) -> Self::RequestBuilder {
+        self.get(uri)
+    }
+
+    fn post(&self, uri: &str) -> Self::RequestBuilder {
+        self.post(uri)
+    }
+
+    fn header(
+        builder: Self::RequestBuilder,
+        key: &Self::HeaderName,
+        value: &str,
+    ) -> Self::RequestBuilder {
+        builder.header(key.clone(), value)
+    }
+
+    async fn get_json<T: DeserializeOwned>(req: Self::RequestBuilder) -> Result<T, Self::Error> {
+        req.send().await?.json::<T>().await
+    }
+
+    async fn post_json<T: Serialize + Sync>(
+        req: Self::RequestBuilder,
+        content: &T,
+    ) -> Result<bool, Self::Error> {
+        let req = req.json(content);
+        let res = req.send().await?;
+        Ok(res.status().is_success())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,8 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
   Enables reqwest with RusTLS support
 * **reqwest-client-11-rustls** -
   Enables reqwest 0.11 with RusTLS support
+* **reqwest-client-13** -
+  Enables reqwest 0.13 with RusTLS support
 * **strict** -
   Turn unexpected fields in API responses into errors
 */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,8 @@ pub mod prelude {
             pub use reqwest::Client as DefaultClient;
         } else if #[cfg(feature = "reqwest-11")] {
             pub use reqwest_11::Client as DefaultClient;
+        } else if #[cfg(feature = "reqwest-13")] {
+            pub use reqwest_13::Client as DefaultClient;
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

Older versions of `reqwest` with `rustls` feature pulls in vulnerable versions of `rustls-webpki`.

High: https://github.com/advisories/GHSA-82j2-j2ch-gfr8

Lows:

- https://github.com/advisories/GHSA-965h-392x-2mh5
- https://github.com/advisories/GHSA-xgp8-3hg3-c2mh

<!-- Does it close an issue? Multiple? -->
Closes #109

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

`Cargo.toml`. One change in 0.13 is that rustls is the default. I didn't bother adding openssl feature. Can do for symmetry, tho?


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
