### PR TITLE
feat: add reqwest 0.13 support (reqwest-client-13)

### DIFF
--- a/crates/unleash-api-client/Cargo.toml
+++ b/crates/unleash-api-client/Cargo.toml
@@ -79,6 +79,13 @@ default-features = false
 features = ["json"]
 optional = true
 
+[dependencies.reqwest-13]
+version = "0.13"
+default-features = false
+features = ["json"]
+optional = true
+package = "reqwest"
+
 [dependencies.reqwest-11]
 version = "0.11"
 default-features = false
@@ -118,8 +125,10 @@ functional = []
 # Built in HTTP clients
 reqwest-client = ["reqwest", "reqwest?/default-tls"]
 reqwest-client-11 = ["reqwest-11", "reqwest-11?/default-tls"]
+reqwest-client-13 = ["reqwest-13", "reqwest-13?/default-tls"]
 # For users that don't want to depend on OpenSSL.
 reqwest-client-11-rustls = ["reqwest-11", "reqwest-11?/rustls-tls"]
+reqwest-client-13-rustls = ["reqwest-13", "reqwest-13?/rustls"]
 reqwest-client-rustls = ["reqwest", "reqwest?/rustls-tls"]
 # To error if an unsupported API feature is present
 strict = []

--- a/crates/unleash-api-client/src/http.rs
+++ b/crates/unleash-api-client/src/http.rs
@@ -5,6 +5,8 @@
 mod reqwest;
 #[cfg(feature = "reqwest-11")]
 mod reqwest_11;
+#[cfg(feature = "reqwest-13")]
+mod reqwest_13;
 mod shim;
 
 pub struct HTTP<C: HttpClient> {

--- a/crates/unleash-api-client/src/http/reqwest_13.rs
+++ b/crates/unleash-api-client/src/http/reqwest_13.rs
@@ -1,0 +1,48 @@
+//! Shim reqwest 0.13 into an unleash HTTP client
+
+// Copyright 2025
+
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+
+use super::HttpClient;
+
+#[async_trait]
+impl HttpClient for reqwest_13::Client {
+    type HeaderName = reqwest_13::header::HeaderName;
+    type Error = reqwest_13::Error;
+    type RequestBuilder = reqwest_13::RequestBuilder;
+
+    fn build_header(name: &'static str) -> Result<Self::HeaderName, Self::Error> {
+        Ok(Self::HeaderName::from_static(name))
+    }
+
+    fn get(&self, uri: &str) -> Self::RequestBuilder {
+        self.get(uri)
+    }
+
+    fn post(&self, uri: &str) -> Self::RequestBuilder {
+        self.post(uri)
+    }
+
+    fn header(
+        builder: Self::RequestBuilder,
+        key: &Self::HeaderName,
+        value: &str,
+    ) -> Self::RequestBuilder {
+        builder.header(key.clone(), value)
+    }
+
+    async fn get_json<T: DeserializeOwned>(req: Self::RequestBuilder) -> Result<T, Self::Error> {
+        req.send().await?.json::<T>().await
+    }
+
+    async fn post_json<T: Serialize + Sync>(
+        req: Self::RequestBuilder,
+        content: &T,
+    ) -> Result<bool, Self::Error> {
+        let req = req.json(content);
+        let res = req.send().await?;
+        Ok(res.status().is_success())
+    }
+}

--- a/crates/unleash-api-client/src/http/reqwest_13.rs
+++ b/crates/unleash-api-client/src/http/reqwest_13.rs
@@ -1,6 +1,6 @@
 //! Shim reqwest 0.13 into an unleash HTTP client
 
-// Copyright 2025
+// Copyright 2026 Cognite AS
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};

--- a/crates/unleash-api-client/src/lib.rs
+++ b/crates/unleash-api-client/src/lib.rs
@@ -111,13 +111,17 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 * **functional** -
   Only relevant to developers: enables the functional test suite.
 * **reqwest-client** -
-  Enables reqwest with OpenSSL TLS support
+  Enables reqwest 0.12 with OpenSSL TLS support
 * **reqwest-client-11** -
   Enables reqwest 0.11 with OpenSSL TLS support
+* **reqwest-client-13** -
+  Enables reqwest 0.13 with OpenSSL TLS support
 * **reqwest-client-rustls** -
-  Enables reqwest with RusTLS support
+  Enables reqwest 0.12 with RusTLS support
 * **reqwest-client-11-rustls** -
   Enables reqwest 0.11 with RusTLS support
+* **reqwest-client-13-rustls** -
+  Enables reqwest 0.13 with RusTLS support
 * **strict** -
   Turn unexpected fields in API responses into errors
 */
@@ -177,7 +181,9 @@ pub mod prelude {
     pub use crate::client::ClientBuilder;
     pub use crate::config::EnvironmentConfig;
     cfg_if::cfg_if! {
-        if #[cfg(feature = "reqwest")] {
+        if #[cfg(feature = "reqwest-13")] {
+            pub use reqwest_13::Client as DefaultClient;
+        } else if #[cfg(feature = "reqwest")] {
             pub use reqwest::Client as DefaultClient;
         } else if #[cfg(feature = "reqwest-11")] {
             pub use reqwest_11::Client as DefaultClient;


### PR DESCRIPTION
## About the changes
Allows consumers on reqwest 0.13 use the built-in `HttpClient` impl instead of rewriting their own thing from scratch.
 
Do note that reqwest 0.13 renamed the `rustls-tls` feature to `rustls`, so `reqwest-client-13-rustls` uses the new feature name.


## Discussion points
No discussion points.