### PR TITLE
feat: rexport feature key macro

### DIFF
--- a/crates/unleash-api-client/benches/is_enabled.rs
+++ b/crates/unleash-api-client/benches/is_enabled.rs
@@ -15,7 +15,6 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use maplit::hashmap;
 use rand::{distr::Alphanumeric, rng, Rng};
 use serde::Deserialize;
-use unleash_api_client_macros::FeatureKey;
 use unleash_types::client_features::ClientFeatures;
 
 use unleash_api_client::api::{Feature, Features, Strategy};

--- a/crates/unleash-api-client/examples/async-std.rs
+++ b/crates/unleash-api-client/examples/async-std.rs
@@ -15,7 +15,6 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         use futures_timer::Delay;
 
         use unleash_api_client::{client, config::EnvironmentConfig};
-        use unleash_api_client_macros::FeatureKey;
         use unleash_api_client::client::FeatureKey;
 
         #[allow(non_camel_case_types)]

--- a/crates/unleash-api-client/examples/threads.rs
+++ b/crates/unleash-api-client/examples/threads.rs
@@ -13,7 +13,6 @@ use unleash_api_client::{
     client::{self, FeatureKey},
     config::EnvironmentConfig,
 };
-use unleash_api_client_macros::FeatureKey;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, FeatureKey)]

--- a/crates/unleash-api-client/examples/tokio.rs
+++ b/crates/unleash-api-client/examples/tokio.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use futures_timer::Delay;
 
 use unleash_api_client::{client::{self, FeatureKey}, config::EnvironmentConfig};
-use unleash_api_client_macros::FeatureKey;
 
 
 #[allow(non_camel_case_types)]

--- a/crates/unleash-api-client/src/client.rs
+++ b/crates/unleash-api-client/src/client.rs
@@ -23,6 +23,8 @@ use crate::context::Context;
 use crate::http::{HttpClient, HTTP};
 use crate::strategy;
 
+pub use unleash_api_client_macros::FeatureKey;
+
 // ----------------- Variant
 
 /// Variant is returned from `Client.get_variant` and is a cut down and


### PR DESCRIPTION
Just a re-export of the feature key macro so users don't have to add a dependency on another crate to get nice UX