### PR TITLE
chore: steal release pr generation from Unleash Edge CI

### DIFF
--- a/.github/workflows/custom-release-pr.yaml
+++ b/.github/workflows/custom-release-pr.yaml
@@ -1,0 +1,294 @@
+name: Custom Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      main_branch:
+        description: "Main branch name"
+        required: false
+        default: "main"
+      dry_run:
+        description: "Dry run (do not push tags or create/update PRs)"
+        required: false
+        default: "false"
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  MAIN_BRANCH: ${{ inputs.main_branch || 'main' }}
+  DRY_RUN: ${{ inputs.dry_run || 'false' }}
+
+jobs:
+  tag-release:
+    name: Tag merged release PR
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    outputs:
+      did_tag: ${{ steps.tag.outputs.did_tag }}
+      release_version: ${{ steps.tag.outputs.release_version }}
+      release_tag: ${{ steps.tag.outputs.release_tag }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
+          private-key: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Fetch tags
+        run: git fetch --tags --force --prune
+
+      - name: Create release tag when a release PR is merged
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "did_tag=false" >> "$GITHUB_OUTPUT"
+
+          subject="$(git log -1 --format=%s)"
+          if [[ ! "${subject}" =~ ^chore\(release\): ]]; then
+            echo "Latest commit is not a release commit: ${subject}"
+            exit 0
+          fi
+
+          macro_version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "unleash-api-client-macros") | .version')"
+
+          sdk_version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "unleash-api-client") | .version')"
+
+          if [[ "${macro_version}" != "${sdk_version}" ]]; then
+            echo "::error::Package versions differ: unleash-api-client=${sdk_version}, unleash-api-client-macros=${macro_version}"
+            exit 1
+          fi
+
+          release_tag="${sdk_version}"
+          if git rev-parse -q --verify "refs/tags/${release_tag}" >/dev/null; then
+            echo "Tag ${release_tag} already exists."
+            exit 0
+          fi
+
+          latest_tag="$(git tag --sort=-version:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' \
+            | head -n1 || true)"
+
+          if [[ -n "${latest_tag}" ]]; then
+            newest="$(printf '%s\n%s\n' "${latest_tag}" "${release_tag}" | sort -V | tail -n1)"
+            if [[ "${newest}" != "${release_tag}" || "${release_tag}" == "${latest_tag}" ]]; then
+              echo "Package version ${release_tag} is not newer than latest tag ${latest_tag}."
+              exit 0
+            fi
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin "${release_tag}"
+
+          echo "did_tag=true" >> "$GITHUB_OUTPUT"
+          echo "release_version=${sdk_version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+  prepare-release-pr:
+    name: Prepare release PR
+    needs:
+      - tag-release
+    if: always() && needs.tag-release.outputs.did_tag != 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
+          private-key: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Ensure tags and main are present
+        run: |
+          git fetch --tags --force --prune
+          git fetch origin "${MAIN_BRANCH}:refs/remotes/origin/${MAIN_BRANCH}"
+
+      - name: Find latest release tag
+        id: latest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_tag="$(git tag --sort=-version:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' \
+            | head -n1 || true)"
+
+          if [[ -z "${latest_tag}" ]]; then
+            current_version="$(cargo metadata --format-version 1 --no-deps \
+              | jq -r '.packages[] | select(.name == "unleash-api-client") | .version')"
+
+            echo "No SemVer release tags found. Using current package version ${current_version} as the base."
+            echo "latest_tag=" >> "$GITHUB_OUTPUT"
+            echo "latest_version=${current_version}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Latest tag: ${latest_tag}"
+            echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+            echo "latest_version=${latest_tag}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Decide semantic release level
+        id: semver
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_tag="${{ steps.latest.outputs.latest_tag }}"
+          if [[ -n "${latest_tag}" ]]; then
+            range="${latest_tag}..origin/${MAIN_BRANCH}"
+            if git diff --quiet "${range}"; then
+              echo "level=none" >> "$GITHUB_OUTPUT"
+              echo "No changes since latest tag."
+              exit 0
+            fi
+
+            log="$(git log --no-merges --format=%s%n%b "${range}" || true)"
+          else
+            if ! git rev-list --max-count=1 "origin/${MAIN_BRANCH}" >/dev/null; then
+              echo "level=none" >> "$GITHUB_OUTPUT"
+              echo "No commits found on origin/${MAIN_BRANCH}."
+              exit 0
+            fi
+
+            log="$(git log --no-merges --format=%s%n%b "origin/${MAIN_BRANCH}" || true)"
+          fi
+
+          level="patch"
+
+          if echo "${log}" | grep -Eiq 'BREAKING[ -]CHANGE'; then
+            level="major"
+          elif echo "${log}" | grep -Eq '^[a-z]+(\([^)]+\))?!:'; then
+            level="major"
+          elif echo "${log}" | grep -Eq '^feat(\([^)]+\))?:'; then
+            level="minor"
+          fi
+
+          echo "level=${level}" >> "$GITHUB_OUTPUT"
+          echo "Computed release level: ${level}"
+
+      - name: Compute next version
+        id: version
+        if: steps.semver.outputs.level != 'none'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          current="${{ steps.latest.outputs.latest_version }}"
+          base="${current%%-*}"
+          IFS='.' read -r major minor patch <<< "${base}"
+
+          case "${{ steps.semver.outputs.level }}" in
+            major) next="$((major + 1)).0.0" ;;
+            minor) next="${major}.$((minor + 1)).0" ;;
+            patch) next="${major}.${minor}.$((patch + 1))" ;;
+            *) echo "Unsupported release level: ${{ steps.semver.outputs.level }}"; exit 1 ;;
+          esac
+
+          echo "previous_version=${current}" >> "$GITHUB_OUTPUT"
+          echo "next_version=${next}" >> "$GITHUB_OUTPUT"
+
+      - name: Install release tools
+        if: steps.semver.outputs.level != 'none' && env.DRY_RUN != 'true'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-edit
+
+      - name: Prepare release changes
+        if: steps.semver.outputs.level != 'none'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          previous_version="${{ steps.version.outputs.previous_version }}"
+          next_version="${{ steps.version.outputs.next_version }}"
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "[DRY RUN] Would bump crates from ${previous_version} to ${next_version}."
+            exit 0
+          fi
+
+          cargo set-version --workspace --offline "${next_version}"
+          cargo update --workspace --offline
+
+          {
+            echo "## Release ${next_version}"
+            echo
+            echo "Bumps both crates from ${previous_version} to ${next_version}."
+            echo
+            echo "### Changes"
+            if [[ -n "${{ steps.latest.outputs.latest_tag }}" ]]; then
+              git log --no-merges --format='- %s' "${{ steps.latest.outputs.latest_tag }}..HEAD"
+            else
+              git log --no-merges --format='- %s' HEAD
+            fi
+          } > RELEASE_PR_BODY.md
+
+      - name: Validate release changes
+        if: steps.semver.outputs.level != 'none' && env.DRY_RUN != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          next_version="${{ steps.version.outputs.next_version }}"
+
+          macro_version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "unleash-api-client-macros") | .version')"
+
+          sdk_version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "unleash-api-client") | .version')"
+
+          pinned_macro_version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "unleash-api-client") | .dependencies[] | select(.name == "unleash-api-client-macros") | .req')"
+
+          if [[ "${macro_version}" != "${next_version}" ]]; then
+            echo "::error::unleash-api-client-macros version is ${macro_version}, expected ${next_version}"
+            exit 1
+          fi
+
+          if [[ "${sdk_version}" != "${next_version}" ]]; then
+            echo "::error::unleash-api-client version is ${sdk_version}, expected ${next_version}"
+            exit 1
+          fi
+
+          if [[ "${pinned_macro_version}" != "^${next_version}" ]]; then
+            echo "::error::unleash-api-client pins unleash-api-client-macros as ${pinned_macro_version}, expected ^${next_version}"
+            exit 1
+          fi
+
+      - name: Create or update release PR
+        if: steps.semver.outputs.level != 'none' && env.DRY_RUN != 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch: release/${{ steps.version.outputs.next_version }}
+          delete-branch: true
+          title: "chore(release): ${{ steps.version.outputs.next_version }}"
+          body-path: RELEASE_PR_BODY.md
+          commit-message: "chore(release): ${{ steps.version.outputs.next_version }}"
+          labels: release


### PR DESCRIPTION
This generates/updates release PRs whenever changes land on main. Should open a PR with patch/minor/major bumps to the version based on commit history. Shamelessly stolen and adapted from [Edge's release flow](https://github.com/Unleash/unleash-edge/blob/main/.github/workflows/custom-release-pr.yaml).

This pins the macro crate to the same version as the SDK crate - that's intentional, I want them to always have a matching version, pretty standard versioning strategy for proc macro crates when they're bound to a parent crate 