### PR TITLE
fix: patch to remame sdkFlavour to sdkFlavor

### DIFF
--- a/crates/unleash-api-client/src/api.rs
+++ b/crates/unleash-api-client/src/api.rs
@@ -15,9 +15,9 @@ pub fn features_endpoint(api_url: &str) -> String {
 pub(crate) struct MetricsMetadata {
     pub(crate) platform_name: String,
     pub(crate) platform_version: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "sdkFlavor", skip_serializing_if = "Option::is_none")]
     pub(crate) sdk_flavour: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "sdkFlavorVersion", skip_serializing_if = "Option::is_none")]
     pub(crate) sdk_flavour_version: Option<String>,
 }
 


### PR DESCRIPTION
While testing the rust-provider for verifying the SDK flavor metadata, found that while the register itself fires fine and we see the metric row, but it's set with the `flavor` blank (see example below).

This happens as Rust puts `sdkFlavour` in the body, but the backend looks for `data.sdkFlavor` (missing the 'u'), it finds nothing and sets flavor metadata to `not-set`.

...It's purely a "flavour" vs "flavor" mispelling. US _vs_ English accent. 
As we went with 'Murican accent so far. Here, it is the patch for the Rust crate to rename the "flavour" to "flavor" and keep us compatible through all the stack. 🇺🇸 X

## 🧪 

```
// Before the change:
client_sdk_versions{sdk_name="unleash-rust-sdk",sdk_version="0.17.0",  ...,sdk_flavor_name="not-set",sdk_flavor_version="not-set"} 3
 
//After the change:
client_sdk_versions{sdk_name="unleash-rust-sdk",sdk_version="0.17.0",...,sdk_flavor_name="unleash-openfeature-rust-provider",sdk_flavor_version="0.1.0"} 1

```